### PR TITLE
BC break: Add $this->request->setCallable() method

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -67,6 +67,7 @@ class CIPHPUnitTest
 		}
 
 		require __DIR__ . '/CIPHPUnitTestCase.php';
+		require __DIR__ . '/CIPHPUnitTestRequest.php';
 		require APPPATH . '/tests/TestCase.php';
 
 		// Restore $_SERVER

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -11,6 +11,25 @@
 class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 {
 	protected $_error_reporting = -1;
+	
+	/**
+	 * @var CIPHPUnitTestRequest
+	 */
+	protected $request;
+
+	/**
+	 * Constructs a test case with the given name.
+	 *
+	 * @param string $name
+	 * @param array  $data
+	 * @param string $dataName
+	 */
+	public function __construct($name = null, array $data = array(), $dataName = '')
+	{
+		parent::__construct($name, $data, $dataName);
+
+		$this->request = new CIPHPUnitTestRequest();
+	}
 
 	public static function setUpBeforeClass()
 	{
@@ -28,20 +47,11 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	 * @param string       $http_method HTTP method
 	 * @param array|string $argv        array of controller,method,arg|uri
 	 * @param array        $params      POST parameters/Query string
-	 * @param callable     $callable    function to run after controller instantiation
+	 * @param callable     $callable    [deprecated] function to run after controller instantiation. Use setRequestCallable() method instead
 	 */
 	public function request($http_method, $argv, $params = [], $callable = null)
 	{
-		if (is_array($argv))
-		{
-			return $this->callControllerMethod(
-				$http_method, $argv, $params, $callable
-			);
-		}
-		else
-		{
-			return $this->requestUri($http_method, $argv, $params, $callable);
-		}
+		return $this->request->request($http_method, $argv, $params, $callable);
 	}
 
 	/**
@@ -56,143 +66,6 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	{
 		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
 		return $this->request($http_method, $argv, $params, $callable);
-	}
-
-	/**
-	 * Call Controller Method
-	 *
-	 * @param string   $http_method HTTP method
-	 * @param array    $argv        controller, method [, arg1, ...]
-	 * @param array    $params      POST parameters/Query string
-	 * @param callable $callable    function to run after controller instantiation
-	 */
-	protected function callControllerMethod($http_method, $argv, $params = [], $callable = null)
-	{
-		$_SERVER['REQUEST_METHOD'] = $http_method;
-		$_SERVER['argv'] = array_merge(['index.php'], $argv);
-
-		if ($http_method === 'POST')
-		{
-			$_POST = $params;
-		}
-		elseif ($http_method === 'GET')
-		{
-			$_GET = $params;
-		}
-
-		$class  = ucfirst($argv[0]);
-		$method = $argv[1];
-
-		// Remove controller and method
-		array_shift($argv);
-		array_shift($argv);
-
-//		$request = [
-//			'REQUEST_METHOD' => $_SERVER['REQUEST_METHOD'],
-//			'class' => $class,
-//			'method' => $method,
-//			'params' => $argv,
-//			'$_GET' => $_GET,
-//			'$_POST' => $_POST,
-//		];
-//		var_dump($request, $_SERVER['argv']);
-
-		// Reset CodeIgniter instance state
-		reset_instance();
-
-		// 404 checking
-		if (! class_exists($class) || ! method_exists($class, $method))
-		{
-			show_404($class.'::'.$method . '() is not found');
-		}
-
-		// Create controller
-		$this->obj = new $class;
-		$this->CI =& get_instance();
-		if (is_callable($callable))
-		{
-			$callable($this->CI);
-		}
-
-		// Call controller method
-		ob_start();
-		call_user_func_array([$this->obj, $method], $argv);
-		$output = ob_get_clean();
-
-		if ($output == '')
-		{
-			$output = $this->CI->output->get_output();
-		}
-
-		return $output;
-	}
-
-	/**
-	 * Request to URI
-	 *
-	 * @param string   $http_method HTTP method
-	 * @param string   $uri         URI string
-	 * @param array    $params      POST parameters/Query string
-	 * @param callable $callable    function to run after controller instantiation
-	 */
-	protected function requestUri($method, $uri, $params = [], $callable = null)
-	{
-		$_SERVER['REQUEST_METHOD'] = $method;
-		$_SERVER['argv'] = ['index.php', $uri];
-
-		if ($method === 'POST')
-		{
-			$_POST = $params;
-		}
-		elseif ($method === 'GET')
-		{
-			$_GET = $params;
-		}
-
-		// Force cli mode because if not, it changes URI (and RTR) behavior
-		$cli = is_cli();
-		set_is_cli(TRUE);
-
-		// Reset CodeIgniter instance state
-		reset_instance();
-
-		// Get route
-		$RTR =& load_class('Router', 'core');
-		$URI =& load_class('URI', 'core');
-		list($class, $method, $params) = $this->getRoute($RTR, $URI);
-
-		// Restore cli mode
-		set_is_cli($cli);
-
-//		$request = [
-//			'REQUEST_METHOD' => $_SERVER['REQUEST_METHOD'],
-//			'class' => $class,
-//			'method' => $method,
-//			'params' => $params,
-//			'$_GET' => $_GET,
-//			'$_POST' => $_POST,
-//		];
-//		var_dump($request, $_SERVER['argv']);
-
-		// Create controller
-		$this->obj = new $class;
-		$this->CI =& get_instance();
-		if (is_callable($callable))
-		{
-			$callable($this->CI);
-		}
-
-		// Call controller method
-		ob_start();
-		call_user_func_array([$this->obj, $method], $params);
-		$output = ob_get_clean();
-
-		if ($output == '')
-		{
-			$output = $this->CI->output->get_output();
-		}
-
-		return $output;
 	}
 
 	/**
@@ -352,60 +225,5 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	public function warningOn()
 	{
 		error_reporting($this->_error_reporting);
-	}
-
-	/**
-	 * Get Route including 404 check
-	 *
-	 * @see core/CodeIgniter.php
-	 *
-	 * @param CI_Route $RTR Router object
-	 * @param CI_URI   $URI URI object
-	 * @return array   [class, method, pararms]
-	 */
-	protected function getRoute($RTR, $URI)
-	{
-		$e404 = FALSE;
-		$class = ucfirst($RTR->class);
-		$method = $RTR->method;
-
-		if (empty($class) OR ! file_exists(APPPATH.'controllers/'.$RTR->directory.$class.'.php'))
-		{
-			$e404 = TRUE;
-		}
-		else
-		{
-			require_once(APPPATH.'controllers/'.$RTR->directory.$class.'.php');
-
-			if ( ! class_exists($class, FALSE) OR $method[0] === '_' OR method_exists('CI_Controller', $method))
-			{
-				$e404 = TRUE;
-			}
-			elseif (method_exists($class, '_remap'))
-			{
-				$params = array($method, array_slice($URI->rsegments, 2));
-				$method = '_remap';
-			}
-			// WARNING: It appears that there are issues with is_callable() even in PHP 5.2!
-			// Furthermore, there are bug reports and feature/change requests related to it
-			// that make it unreliable to use in this context. Please, DO NOT change this
-			// work-around until a better alternative is available.
-			elseif ( ! in_array(strtolower($method), array_map('strtolower', get_class_methods($class)), TRUE))
-			{
-				$e404 = TRUE;
-			}
-		}
-
-		if ($e404)
-		{
-			show_404($RTR->directory.$class.'/'.$method.' is not found');
-		}
-
-		if ($method !== '_remap')
-		{
-			$params = array_slice($URI->rsegments, 2);
-		}
-
-		return [$class, $method, $params];
 	}
 }

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -47,7 +47,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	 * @param string       $http_method HTTP method
 	 * @param array|string $argv        array of controller,method,arg|uri
 	 * @param array        $params      POST parameters/Query string
-	 * @param callable     $callable    [deprecated] function to run after controller instantiation. Use setRequestCallable() method instead
+	 * @param callable     $callable    [deprecated] function to run after controller instantiation. Use $this->request->setCallable() method instead
 	 */
 	public function request($http_method, $argv, $params = [], $callable = null)
 	{

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -20,7 +20,7 @@ class CIPHPUnitTestRequest
 	 * @param string       $http_method HTTP method
 	 * @param array|string $argv        array of controller,method,arg|uri
 	 * @param array        $params      POST parameters/Query string
-	 * @param callable     $callable    [deprecated] function to run after controller instantiation. Use setRequestCallable() method instead
+	 * @param callable     $callable    [deprecated] function to run after controller instantiation. Use setCallable() method instead
 	 */
 	public function request($http_method, $argv, $params = [], $callable = null)
 	{
@@ -42,7 +42,7 @@ class CIPHPUnitTestRequest
 	 * @param string   $http_method HTTP method
 	 * @param array    $argv        controller, method [, arg1, ...]
 	 * @param array    $params      POST parameters/Query string
-	 * @param callable $callable    [deprecated] function to run after controller instantiation. Use setRequestCallable() method instead
+	 * @param callable $callable    [deprecated] function to run after controller instantiation. Use setCallable() method instead
 	 */
 	protected function callControllerMethod($http_method, $argv, $params = [], $callable = null)
 	{
@@ -116,7 +116,7 @@ class CIPHPUnitTestRequest
 	 * @param string   $http_method HTTP method
 	 * @param string   $uri         URI string
 	 * @param array    $params      POST parameters/Query string
-	 * @param callable $callable    [deprecated] function to run after controller instantiation. Use setRequestCallable() method instead
+	 * @param callable $callable    [deprecated] function to run after controller instantiation. Use setCallable() method instead
 	 */
 	protected function requestUri($method, $uri, $params = [], $callable = null)
 	{

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -1,0 +1,240 @@
+<?php
+
+class CIPHPUnitTestRequest
+{
+	protected $callable;
+
+	/**
+	 * Set callable
+	 * 
+	 * @param callable $callable function to run after controller instantiation
+	 */
+	public function setCallable(callable $callable)
+	{
+		$this->callable = $callable;
+	}
+
+	/**
+	 * Request to Controller
+	 *
+	 * @param string       $http_method HTTP method
+	 * @param array|string $argv        array of controller,method,arg|uri
+	 * @param array        $params      POST parameters/Query string
+	 * @param callable     $callable    [deprecated] function to run after controller instantiation. Use setRequestCallable() method instead
+	 */
+	public function request($http_method, $argv, $params = [], $callable = null)
+	{
+		if (is_array($argv))
+		{
+			return $this->callControllerMethod(
+				$http_method, $argv, $params, $callable
+			);
+		}
+		else
+		{
+			return $this->requestUri($http_method, $argv, $params, $callable);
+		}
+	}
+
+	/**
+	 * Call Controller Method
+	 *
+	 * @param string   $http_method HTTP method
+	 * @param array    $argv        controller, method [, arg1, ...]
+	 * @param array    $params      POST parameters/Query string
+	 * @param callable $callable    [deprecated] function to run after controller instantiation. Use setRequestCallable() method instead
+	 */
+	protected function callControllerMethod($http_method, $argv, $params = [], $callable = null)
+	{
+		$_SERVER['REQUEST_METHOD'] = $http_method;
+		$_SERVER['argv'] = array_merge(['index.php'], $argv);
+
+		if ($http_method === 'POST')
+		{
+			$_POST = $params;
+		}
+		elseif ($http_method === 'GET')
+		{
+			$_GET = $params;
+		}
+
+		$class  = ucfirst($argv[0]);
+		$method = $argv[1];
+
+		// Remove controller and method
+		array_shift($argv);
+		array_shift($argv);
+
+//		$request = [
+//			'REQUEST_METHOD' => $_SERVER['REQUEST_METHOD'],
+//			'class' => $class,
+//			'method' => $method,
+//			'params' => $argv,
+//			'$_GET' => $_GET,
+//			'$_POST' => $_POST,
+//		];
+//		var_dump($request, $_SERVER['argv']);
+
+		// Reset CodeIgniter instance state
+		reset_instance();
+
+		// 404 checking
+		if (! class_exists($class) || ! method_exists($class, $method))
+		{
+			show_404($class.'::'.$method . '() is not found');
+		}
+
+		// Create controller
+		$this->obj = new $class;
+		$this->CI =& get_instance();
+		if (is_callable($callable))
+		{
+			$callable($this->CI);	// @deprecated
+		}
+		elseif (is_callable($this->callable))
+		{
+			$callable = $this->callable;
+			$callable($this->CI);
+		}
+
+		// Call controller method
+		ob_start();
+		call_user_func_array([$this->obj, $method], $argv);
+		$output = ob_get_clean();
+
+		if ($output == '')
+		{
+			$output = $this->CI->output->get_output();
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Request to URI
+	 *
+	 * @param string   $http_method HTTP method
+	 * @param string   $uri         URI string
+	 * @param array    $params      POST parameters/Query string
+	 * @param callable $callable    [deprecated] function to run after controller instantiation. Use setRequestCallable() method instead
+	 */
+	protected function requestUri($method, $uri, $params = [], $callable = null)
+	{
+		$_SERVER['REQUEST_METHOD'] = $method;
+		$_SERVER['argv'] = ['index.php', $uri];
+
+		if ($method === 'POST')
+		{
+			$_POST = $params;
+		}
+		elseif ($method === 'GET')
+		{
+			$_GET = $params;
+		}
+
+		// Force cli mode because if not, it changes URI (and RTR) behavior
+		$cli = is_cli();
+		set_is_cli(TRUE);
+
+		// Reset CodeIgniter instance state
+		reset_instance();
+
+		// Get route
+		$RTR =& load_class('Router', 'core');
+		$URI =& load_class('URI', 'core');
+		list($class, $method, $params) = $this->getRoute($RTR, $URI);
+
+		// Restore cli mode
+		set_is_cli($cli);
+
+//		$request = [
+//			'REQUEST_METHOD' => $_SERVER['REQUEST_METHOD'],
+//			'class' => $class,
+//			'method' => $method,
+//			'params' => $params,
+//			'$_GET' => $_GET,
+//			'$_POST' => $_POST,
+//		];
+//		var_dump($request, $_SERVER['argv']);
+
+		// Create controller
+		$this->obj = new $class;
+		$this->CI =& get_instance();
+		if (is_callable($callable))
+		{
+			$callable($this->CI);	// @deprecated
+		}
+		elseif (is_callable($this->callable))
+		{
+			$callable = $this->callable;
+			$callable($this->CI);
+		}
+
+		// Call controller method
+		ob_start();
+		call_user_func_array([$this->obj, $method], $params);
+		$output = ob_get_clean();
+
+		if ($output == '')
+		{
+			$output = $this->CI->output->get_output();
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Get Route including 404 check
+	 *
+	 * @see core/CodeIgniter.php
+	 *
+	 * @param CI_Route $RTR Router object
+	 * @param CI_URI   $URI URI object
+	 * @return array   [class, method, pararms]
+	 */
+	protected function getRoute($RTR, $URI)
+	{
+		$e404 = FALSE;
+		$class = ucfirst($RTR->class);
+		$method = $RTR->method;
+
+		if (empty($class) OR ! file_exists(APPPATH.'controllers/'.$RTR->directory.$class.'.php'))
+		{
+			$e404 = TRUE;
+		}
+		else
+		{
+			require_once(APPPATH.'controllers/'.$RTR->directory.$class.'.php');
+
+			if ( ! class_exists($class, FALSE) OR $method[0] === '_' OR method_exists('CI_Controller', $method))
+			{
+				$e404 = TRUE;
+			}
+			elseif (method_exists($class, '_remap'))
+			{
+				$params = array($method, array_slice($URI->rsegments, 2));
+				$method = '_remap';
+			}
+			// WARNING: It appears that there are issues with is_callable() even in PHP 5.2!
+			// Furthermore, there are bug reports and feature/change requests related to it
+			// that make it unreliable to use in this context. Please, DO NOT change this
+			// work-around until a better alternative is available.
+			elseif ( ! in_array(strtolower($method), array_map('strtolower', get_class_methods($class)), TRUE))
+			{
+				$e404 = TRUE;
+			}
+		}
+
+		if ($e404)
+		{
+			show_404($RTR->directory.$class.'/'.$method.' is not found');
+		}
+
+		if ($method !== '_remap')
+		{
+			$params = array_slice($URI->rsegments, 2);
+		}
+
+		return [$class, $method, $params];
+	}
+}

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -101,7 +101,7 @@ $this->request->setCallable(
 		$CI->load->library('user_agent');
 	};
 );
-$output = $this->request('GET', ['Bbs', 'index'], []);
+$output = $this->request('GET', ['Bbs', 'index']);
 ~~~
 
 #### `TestCase::ajaxRequest($method, $argv, $params = [], $callable = null)`

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -68,7 +68,7 @@ load_class_instance('email', $email);
 |`$method`  | string       | HTTP method                                    |
 |`$argv`    | array/string | controller, method [, arg1, ...] / URI string  |
 |`$params`  | array        | POST parameters / Query string                 |
-|`$callable`| callable     | function to run after controller instantiation |
+|`$callable`| callable     | [Deprecated] function to run after controller instantiation |
 
 `returns` (string) output strings (view)
 
@@ -82,11 +82,26 @@ $output = $this->request('GET', ['Form', 'index']);
 $output = $this->request('GET', 'products/shoes/show/123');
 ~~~
 
+`$callable` is deprecated. Use `$this->request->setCallable()` method instead.
+
+*before:*
 ~~~php
 $load_agent = function ($CI) {
 	$CI->load->library('user_agent');
 };
 $output = $this->request('GET', ['Bbs', 'index'], [], $load_agent);
+~~~
+
+↓
+
+*after:*
+~~~php
+$this->request->setCallable(
+	function ($CI) {
+		$CI->load->library('user_agent');
+	};
+);
+$output = $this->request('GET', ['Bbs', 'index'], []);
 ~~~
 
 #### `TestCase::ajaxRequest($method, $argv, $params = [], $callable = null)`
@@ -96,7 +111,7 @@ $output = $this->request('GET', ['Bbs', 'index'], [], $load_agent);
 |`$method`  | string       | HTTP method                                    |
 |`$argv`    | array/string | controller, method [, arg1, ...] / URI string  |
 |`$params`  | array        | POST parameters / Query string                 |
-|`$callable`| callable     | function to run after controller instantiation |
+|`$callable`| callable     | [Deprecated] function to run after controller instantiation |
 
 `returns` (string) output strings
 

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -171,11 +171,17 @@ See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/m
 
 #### Request and Use Mocks
 
-You can use the 4th argument of [$this->request()](FunctionAndClassReference.md#testcaserequestmethod-argv-params---callable--null) method in *CI PHPUnit Test*. [$this->getDouble()](FunctionAndClassReference.md#testcasegetdoubleclassname-params) is a helper method in *CI PHPUnit Test*.
+You can use `$this->request->setCallable()` method in *CI PHPUnit Test*. [$this->getDouble()](FunctionAndClassReference.md#testcasegetdoubleclassname-params) is a helper method in *CI PHPUnit Test*.
 
 ~~~php
 	public function test_send_okay()
 	{
+		$this->request->setCallable(
+			function ($CI) {
+				$email = $this->getDouble('CI_Email', ['send' => TRUE]);
+				$CI->email = $email;
+			}
+		);
 		$output = $this->request(
 			'POST',
 			['Contact', 'send'],
@@ -183,11 +189,7 @@ You can use the 4th argument of [$this->request()](FunctionAndClassReference.md#
 				'name' => 'Mike Smith',
 				'email' => 'mike@example.jp',
 				'body' => 'This is test mail.',
-			],
-			function ($CI) {
-				$email = $this->getDouble('CI_Email', ['send' => TRUE]);
-				$CI->email = $email;
-			}
+			]
 		);
 		$this->assertContains('Mail sent', $output);
 	}


### PR DESCRIPTION
`$this->request()` method has or will have too many params.

This PR removes the 4th param. Instead of it, we add `$this->request` object and `setCallable()` method.

*before:*
~~~php
$load_agent = function ($CI) {
	$CI->load->library('user_agent');
};
$output = $this->request('GET', ['Bbs', 'index'], [], $load_agent);
~~~

↓

*after:*
~~~php
$this->request->setCallable(
	function ($CI) {
		$CI->load->library('user_agent');
	};
);
$output = $this->request('GET', ['Bbs', 'index']);
~~~
