### PR TITLE
Add functionality to enable hooks for controller

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -54,7 +54,7 @@ class CIPHPUnitTestRequest
 	 * @param array    $request_params POST parameters/Query string
 	 * @param callable $callable       [deprecated] function to run after controller instantiation. Use setCallable() method instead
 	 */
-	protected function callControllerMethod($http_method, $argv, $request_params, $callable)
+	protected function callControllerMethod($http_method, $argv, $request_params, $callable = null)
 	{
 		$_SERVER['REQUEST_METHOD'] = $http_method;
 		$_SERVER['argv'] = array_merge(['index.php'], $argv);
@@ -113,7 +113,7 @@ class CIPHPUnitTestRequest
 	 * @param array    $request_params POST parameters/Query string
 	 * @param callable $callable       [deprecated] function to run after controller instantiation. Use setCallable() method instead
 	 */
-	protected function requestUri($http_method, $uri, $request_params, $callable)
+	protected function requestUri($http_method, $uri, $request_params, $callable = null)
 	{
 		$_SERVER['REQUEST_METHOD'] = $http_method;
 		$_SERVER['argv'] = ['index.php', $uri];
@@ -172,12 +172,12 @@ class CIPHPUnitTestRequest
 		}
 
 		// Create controller
-		$this->obj = new $class;
-		$this->CI =& get_instance();
+		$controller = new $class;
+		$CI =& get_instance();
 		if (is_callable($this->callable))
 		{
 			$callable = $this->callable;
-			$callable($this->CI);
+			$callable($CI);
 		}
 
 		if ($this->enableHooks)
@@ -186,12 +186,12 @@ class CIPHPUnitTestRequest
 		}
 
 		// Call controller method
-		call_user_func_array([$this->obj, $method], $params);
+		call_user_func_array([$controller, $method], $params);
 		$output = ob_get_clean();
 
 		if ($output == '')
 		{
-			$output = $this->CI->output->get_output();
+			$output = $CI->output->get_output();
 		}
 
 		if ($this->enableHooks)

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -104,6 +104,13 @@ $this->request->setCallable(
 $output = $this->request('GET', ['Bbs', 'index']);
 ~~~
 
+If you want to enable hooks, call `$this->request->enableHooks()` method. It enables only `pre_controller`, `post_controller_constructor`, `post_controller` hooks.
+
+~~~php
+$this->request->enableHooks();
+$output = $this->request('GET', 'products/shoes/show/123');
+~~~
+
 #### `TestCase::ajaxRequest($method, $argv, $params = [], $callable = null)`
 
 | param     | type         | description                                    |

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -267,6 +267,17 @@ If you use it, you can write tests like this:
 
 See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Redirect_test.php).
 
+#### Controller with Hooks
+
+If you want to enable hooks, call `$this->request->enableHooks()` method. It enables `pre_controller`, `post_controller_constructor`, `post_controller` hooks.
+
+~~~php
+$this->request->enableHooks();
+$output = $this->request('GET', 'products/shoes/show/123');
+~~~
+
+See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Hook_test.php).
+
 #### Controller with Name Collision
 
 If you have two controllers with the exact same name, PHP Fatal error stops PHPUnit testing.


### PR DESCRIPTION
You can enable `pre_controller`, `post_controller_constructor`, `post_controller` hook when you call `$this->request()`.

Example:
~~~php
$this->request->enableHooks();
$output = $this->request('GET', ['Welcome', 'index']);
~~~
