### PR TITLE
[BC break] Change how to test redirect(), show_404(), show_error()

### DIFF
--- a/application/helpers/MY_url_helper.php
+++ b/application/helpers/MY_url_helper.php
@@ -97,6 +97,6 @@ function redirect($uri = '', $method = 'auto', $code = NULL)
 			ob_end_clean();
 		}
 
-		throw new PHPUnit_Framework_Exception('Redirect to ' . $uri, $code);
+		throw new CIPHPUnitTestRedirectException('Redirect to ' . $uri, $code);
 	}
 }

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -22,6 +22,13 @@ class CIPHPUnitTest
 		];
 		$_SERVER['argc'] = 2;
 
+		require __DIR__ . '/CIPHPUnitTestCase.php';
+		require __DIR__ . '/CIPHPUnitTestRequest.php';
+		require __DIR__ . '/CIPHPUnitTestDouble.php';
+		require __DIR__ . '/exceptions/CIPHPUnitTestRedirectException.php';
+		require __DIR__ . '/exceptions/CIPHPUnitTestShow404Exception.php';
+		require __DIR__ . '/exceptions/CIPHPUnitTestShowErrorException.php';
+
 		// Replace a few Common functions
 		require __DIR__ . '/replacing/core/Common.php';
 		require BASEPATH . 'core/Common.php';
@@ -61,14 +68,11 @@ class CIPHPUnitTest
 			ob_start();
 			require_once BASEPATH . 'core/CodeIgniter.php';
 			ob_end_clean();
-		} catch (PHPUnit_Framework_Exception $e) {
+		} catch (CIPHPUnitTestShow404Exception $e) {
 			// Catch 404 exception
 			new CI_Controller();
 		}
 
-		require __DIR__ . '/CIPHPUnitTestCase.php';
-		require __DIR__ . '/CIPHPUnitTestRequest.php';
-		require __DIR__ . '/CIPHPUnitTestDouble.php';
 		require APPPATH . '/tests/TestCase.php';
 
 		// Restore $_SERVER

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -200,19 +200,36 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	 * @param string $uri  URI to redirect
 	 * @param int    $code Response Code
 	 */
-	public function setExpectedRedirect($uri, $code = null)
+	public function assertRedirect($uri, $code = null)
 	{
+		$status = $this->request->getStatus();
+
+		if ($status['redirect'] === null)
+		{
+			$this->fail('redirect() is not called.');
+		}
+
 		if (! function_exists('site_url'))
 		{
 			$CI =& get_instance();
 			$CI->load->helper('url');
 		}
+		$absolute_url = site_url($uri);
+		$expected = 'Redirect to ' . $absolute_url;
 
-		$absolute_uri = site_url($uri);
-		$exceptionMessage = 'Redirect to ' . $absolute_uri;
-
-		$this->setExpectedException(
-			'PHPUnit_Framework_Exception', $exceptionMessage, $code
+		$this->assertSame(
+			$expected,
+			$status['redirect'],
+			'URL to redirect is not ' . $expected . ' but ' . $status['redirect'] . '.'
 		);
+
+		if ($code !== null)
+		{
+			$this->assertSame(
+				$code,
+				$status['code'],
+				'Status code is not ' . $code . ' but ' . $status['code'] . '.'
+			);
+		}
 	}
 }

--- a/application/tests/_ci_phpunit_test/exceptions/CIPHPUnitTestRedirectException.php
+++ b/application/tests/_ci_phpunit_test/exceptions/CIPHPUnitTestRedirectException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+class CIPHPUnitTestRedirectException extends RuntimeException
+{
+}

--- a/application/tests/_ci_phpunit_test/exceptions/CIPHPUnitTestShow404Exception.php
+++ b/application/tests/_ci_phpunit_test/exceptions/CIPHPUnitTestShow404Exception.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+class CIPHPUnitTestShow404Exception extends RuntimeException
+{
+}

--- a/application/tests/_ci_phpunit_test/exceptions/CIPHPUnitTestShowErrorException.php
+++ b/application/tests/_ci_phpunit_test/exceptions/CIPHPUnitTestShowErrorException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+class CIPHPUnitTestShowErrorException extends RuntimeException
+{
+}

--- a/application/tests/_ci_phpunit_test/replacing/core/Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/Common.php
@@ -152,7 +152,7 @@ function show_error($message, $status_code = 500, $heading = 'An Error Was Encou
 		ob_end_clean();
 	}
 
-	throw new PHPUnit_Framework_Exception($message, $status_code);
+	throw new CIPHPUnitTestShowErrorException($message, $status_code);
 }
 
 function show_404($page = '', $log_error = TRUE)
@@ -162,7 +162,7 @@ function show_404($page = '', $log_error = TRUE)
 		ob_end_clean();
 	}
 
-	throw new PHPUnit_Framework_Exception($page, 404);
+	throw new CIPHPUnitTestShow404Exception($page, 404);
 }
 
 function set_status_header($code = 200, $text = '')
@@ -233,8 +233,9 @@ function set_status_header($code = 200, $text = '')
 	$CI =& get_instance();
 	$output = $CI->output;
 	$output->_status = [
-		'code' => $code,
-		'text' => $text
+		'code'     => $code,
+		'text'     => $text,
+		'redirect' => null,
 	];
 
 	if (is_cli())

--- a/application/tests/controllers/Welcome_test.php
+++ b/application/tests/controllers/Welcome_test.php
@@ -16,13 +16,10 @@ class Welcome_test extends TestCase
 		$this->assertContains('<title>Welcome to CodeIgniter</title>', $output);
 	}
 
-	/**
-	 * @expectedException		PHPUnit_Framework_Exception
-	 * @expectedExceptionCode	404
-	 */
 	public function test_method_404()
 	{
 		$this->request('GET', ['Welcome', 'method_not_exist']);
+		$this->assertResponseCode(404);
 	}
 
 	public function test_APPPATH()

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,0 +1,37 @@
+# Change Log for CI PHPUnit Test for CodeIgniter 3.0
+
+## v0.4.0 (Not Released)
+
+### Changed
+
+* Changed `MY_url_helper.php` as sample. If you use new `MY_url_helper.php`, you must update your tests for `redirect()` using new `$this->assertRedirect()` method. See [How to Write Tests](HowToWriteTests.md#redirect).
+* Changed how to test `show_404()` and `show_error()`. If you don't want to update your tests, set property `$bc_mode_throw_PHPUnit_Framework_Exception` `true` in `CIPHPUnitTestRequest` class. But `$bc_mode_throw_PHPUnit_Framework_Exception` is deprecated. See [How to Write Tests](HowToWriteTests.md#show_error-and-show_404).
+
+### Added
+
+* `$this->assertResponseCode()` to check response code in controller tests. See [Function/Class Reference](FunctionAndClassReference.md#testcaseassertresponsecodecode).
+* `$this->assertRedirect()` to check if `redirect()` is called in controller tests. See [Function/Class Reference](FunctionAndClassReference.md#testcaseassertredirecturi-code--null).
+
+## v0.3.0 (2015/07/14)
+
+### Deprecated
+
+* 4th param `$callable` of `$this->request()` and  `$this->ajaxRequest()`. Use `$this->request->setCallable()` method instead. See [Function/Class Reference](https://github.com/kenjis/ci-phpunit-test/blob/7ef8acd7d7f80c1cf342a12f9464d2156b749b92/docs/FunctionAndClassReference.md#testcaserequestmethod-argv-params---callable--null)
+
+### Added
+
+* `$this->request->setCallable()` See [How to Write Tests](https://github.com/kenjis/ci-phpunit-test/blob/7ef8acd7d7f80c1cf342a12f9464d2156b749b92/docs/HowToWriteTests.md#request-and-use-mocks)
+* You can enable hooks for controller in controller testing. `$this->request->enableHooks()` is added. See [How to Write Tests](https://github.com/kenjis/ci-phpunit-test/blob/7ef8acd7d7f80c1cf342a12f9464d2156b749b92/docs/HowToWriteTests.md#controller-with-hooks)
+
+## v0.2.0 (2015/06/19)
+
+* Change `MY_url_helper.php` as sample. If you use new `MY_url_helper.php`, you must catch `PHPUnit_Framework_Exception` when you test code using `redirect()`
+* Improve documentation
+
+## v0.1.1 (2015/06/15)
+
+* Improve installation. See [Installation](https://github.com/kenjis/ci-phpunit-test#installation)
+* Fix bug that Bootstrap outputs 404 page when 404_override
+* Fix bug that risky tests occur #14
+
+## v0.1.0 (2015/06/12)

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -16,7 +16,7 @@ version: **master** |
 		- [`request->enableHooks()`](#request-enablehooks)
 	- [`TestCase::ajaxRequest($method, $argv, $params = [], $callable = null)`](#testcaseajaxrequestmethod-argv-params---callable--null)
 	- [`TestCase::assertResponseCode($code)`](#testcaseassertresponsecodecode)
-	- [`TestCase::setExpectedRedirect($uri, $code)`](#testcasesetexpectedredirecturi-code)
+	- [`TestCase::assertRedirect($uri, $code = null)`](#testcaseassertredirecturi-code--null)
 	- [`TestCase::getDouble($classname, $params)`](#testcasegetdoubleclassname-params)
 	- [`TestCase::verifyInvoked($mock, $method, $params)`](#testcaseverifyinvokedmock-method-params)
 	- [`TestCase::verifyInvokedOnce($mock, $method, $params)`](#testcaseverifyinvokedoncemock-method-params)
@@ -159,21 +159,14 @@ The same as `TestCase::request()`, but this makes a Ajax request. This adds only
 
 Check for a specific response code on your controller tests.
 
-#### `TestCase::setExpectedRedirect($uri, $code)`
+#### `TestCase::assertRedirect($uri, $code = null)`
 
 | param   | type   | description      |
 |---------|--------|------------------|
-|`$uri `  | string | URI to redirect  |
+|`$uri`   | string | URI to redirect  |
 |`$code`  | int    | HTTP status code |
 
-Check if `redirect()` is called on controller tests.
-
-This method needs [MY_url_helper.php](../application/helpers/MY_url_helper.php).
-
-~~~php
-$this->setExpectedRedirect('/', 302);
-$this->request('GET', 'welcome/index');
-~~~
+Check if `redirect()` is called on your controller tests.
 
 #### `TestCase::getDouble($classname, $params)`
 

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -236,14 +236,12 @@ See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/m
 
 #### Check Status Code
 
-When you use `$this->output->set_status_header()` in your code, you can use [$this->assertResponseCode()](FunctionAndClassReference.md#testcaseassertresponsecodecode) method in *CI PHPUnit Test*.
+You can use [$this->assertResponseCode()](FunctionAndClassReference.md#testcaseassertresponsecodecode) method in *CI PHPUnit Test*.
 
 ~~~php
 		$this->request('GET', 'welcome');
 		$this->assertResponseCode(200);
 ~~~
-
-But when you use `show_error()` and `show_404()` in your code, see [show_error() and show_404()](#show_error-and-show_404).
 
 #### Examine DOM in Controller Output
 
@@ -291,31 +289,87 @@ If you use it, you can write tests like this:
 ~~~php
 	public function test_index()
 	{
-		$this->setExpectedRedirect('login', 302);
-		$output = $this->request('GET', ['Admin', 'index']);
+		$this->request('GET', ['Admin', 'index']);
+		$this->assertRedirect('login', 302);
 	}
 ~~~
 
-[$this->setExpectedRedirect()](FunctionAndClassReference.md#testcasesetexpectedredirecturi-code) is a method in *CI PHPUnit Test*.
+[$this->assertRedirect()](FunctionAndClassReference.md#testcaseassertredirecturi-code--null) is a method in *CI PHPUnit Test*.
 
 See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Redirect_test.php).
 
-#### `show_error()` and `show_404()`
+**Upgrade Note for v0.4.0**
 
-`show_error()` and `show_404()` in *CI PHPUnit Test* throw `PHPUnit_Framework_Exception`.
+v0.4.0 has new `MY_url_helper.php`. If you use it, you must update your tests.
 
+*before:*
 ~~~php
 	/**
-	* @expectedException		PHPUnit_Framework_Exception
-	* @expectedExceptionCode	404
-	*/
+	 * @expectedException				PHPUnit_Framework_Exception
+	 * @expectedExceptionCode			302
+	 * @expectedExceptionMessageRegExp	!\ARedirect to http://localhost/\z!
+	 */
 	public function test_index()
 	{
-		$output = $this->request('GET', ['nocontroller', 'noaction']);
+		$output = $this->request('GET', ['Redirect', 'index']);
+	}
+~~~
+
+↓
+
+*after:*
+~~~php
+	public function test_index()
+	{
+		$this->request('GET', ['Redirect', 'index']);
+		$this->assertRedirect('/', 302);
+	}
+~~~
+
+#### `show_error()` and `show_404()`
+
+You can use [$this->assertResponseCode()](FunctionAndClassReference.md#testcaseassertresponsecodecode) method in *CI PHPUnit Test*.
+
+~~~php
+	public function test_index()
+	{
+		$this->request('GET', ['nocontroller', 'noaction']);
+		$this->assertResponseCode(404);
 	}
 ~~~
 
 See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Nocontroller_test.php).
+
+If you don't call `$this->request()` in your tests, `show_error()` throws `CIPHPUnitTestShowErrorException` and `show_404()` throws `CIPHPUnitTestShow404Exception`. So you must expect the exceptions. You can use `@expectedException` annotation in PHPUnit.
+
+**Upgrade Note for v0.4.0**
+
+v0.4.0 has changed how to test `show_error()` and `show_404()`. You must update your tests.
+
+*before:*
+~~~php
+	/**
+	 * @expectedException		PHPUnit_Framework_Exception
+	 * @expectedExceptionCode	404
+	 */
+	public function test_index()
+	{
+		$this->request('GET', 'show404');
+	}
+~~~
+
+↓
+
+*after:*
+~~~php
+	public function test_index()
+	{
+		$this->request('GET', 'show404');
+		$this->assertResponseCode(404);
+	}
+~~~
+
+If you don't want to update your tests, set property `$bc_mode_throw_PHPUnit_Framework_Exception` `true` in [CIPHPUnitTestRequest](../application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php) class. But `$bc_mode_throw_PHPUnit_Framework_Exception` is deprecated.
 
 #### Controller with Hooks
 


### PR DESCRIPTION
### New way to write tests

With this PR, you can write tests like below. We have to update `MY_url_helper.php`, too.

`redirect()`:
~~~php
$this->request('GET', 'admin');
$this->assertRedirect('login', 302);

// or without status code
$this->request('GET', 'admin');
$this->assertRedirect('login');
~~~

`show_404()` and `show_error()`:
~~~php
$this->request('GET', ['Welcome', 'method_not_exist']);
$this->assertResponseCode(404);

$this->request('GET', ['Foo', 'internal_error']);
$this->assertResponseCode(500);
~~~

### Backward Compatibility mode

If you don't update `MY_url_helper.php`, and set `CIPHPUnitTestRequest::bc_mode_throw_PHPUnit_Framework_Exception` `true`, your tests should pass without modifications.

### Internal

* `show_error()` throws `CIPHPUnitTestShowErrorException`
* `show_404()` throws `CIPHPUnitTestShow404Exception`

and `$this->request()` catch them.

If you write pure unit tests for controller classes, you must catch these exceptions.
