### PR TITLE
Enalbe to inject mock objects before controller instantiation

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -1,11 +1,28 @@
 <?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
 
 class CIPHPUnitTestRequest
 {
+	/**
+	 * @var callable callable post controller constructor
+	 */
 	protected $callable;
+	
+	/**
+	 * @var callable callable pre controller constructor
+	 */
+	protected $callablePreConstructor;
+
 	protected $enableHooks = false;
 	protected $CI;
-
+	
 	/**
 	 * @var bool whether throwing PHPUnit_Framework_Exception or not
 	 * 
@@ -23,6 +40,16 @@ class CIPHPUnitTestRequest
 	public function setCallable(callable $callable)
 	{
 		$this->callable = $callable;
+	}
+
+	/**
+	 * Set callable pre constructor
+	 * 
+	 * @param callable $callable function to run before controller instantiation
+	 */
+	public function setCallablePreConstructor(callable $callable)
+	{
+		$this->callablePreConstructor = $callable;
 	}
 
 	/**
@@ -224,6 +251,13 @@ class CIPHPUnitTestRequest
 		{
 			$EXT =& load_class('Hooks', 'core');
 			$EXT->call_hook('pre_controller');
+		}
+
+		// Run callablePreConstructor
+		if (is_callable($this->callablePreConstructor))
+		{
+			$callable = $this->callablePreConstructor;
+			$callable();
 		}
 
 		// Create controller

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -9,6 +9,7 @@
 ### Added
 
 * Monkey Patching on `exit()`. *CI PHPUnit Test* could convert `exit()` in your code to Exception on the fly. See [#32](https://github.com/kenjis/ci-phpunit-test/pull/32).
+* `$this->request->setCallablePreConstructor()` to inject mocks into your controller constructors. See [#29](https://github.com/kenjis/ci-phpunit-test/pull/29).
 
 ## v0.4.0 (2015/07/21)
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -14,6 +14,7 @@ version: **master** |
 - [*class* TestCase](#class-testcase)
 	- [`TestCase::request($method, $argv, $params = [], $callable = null)`](#testcaserequestmethod-argv-params---callable--null)
 		- [`request->setCallable()`](#request-setcallable)
+		- [`request->setCallablePreConstructor()`](#request-setcallablepreconstructor)
 		- [`request->enableHooks()`](#request-enablehooks)
 	- [`TestCase::ajaxRequest($method, $argv, $params = [], $callable = null)`](#testcaseajaxrequestmethod-argv-params---callable--null)
 	- [`TestCase::assertResponseCode($code)`](#testcaseassertresponsecodecode)
@@ -130,6 +131,23 @@ $this->request->setCallable(
 	};
 );
 $output = $this->request('GET', ['Bbs', 'index']);
+~~~
+
+##### `request->setCallablePreConstructor()`
+
+Set function to run before controller instantiation.
+
+~~~php
+$this->request->setCallablePreConstructor(
+	function () {
+		// Get mock object
+		$auth = $this->getDouble(
+			'Ion_auth', ['logged_in' => TRUE]
+		);
+		// Inject mock object
+		load_class_instance('ion_auth', $auth);
+	}
+);
 ~~~
 
 ##### `request->enableHooks()`

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -347,6 +347,31 @@ You can use [$this->request->setCallable()](FunctionAndClassReference.md#request
 
 See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Mock_phpunit_test.php).
 
+The function you set by `$this->request->setCallable()` runs after controller instantiation. So you can't inject mocks into controller constructor.
+
+In that case, You can use [$this->request->setCallablePreConstructor()](FunctionAndClassReference.md#request-setcallablepreconstructor) method and [load_class_instance()](FunctionAndClassReference.md#function-load_class_instanceclassname-instance) function in *CI PHPUnit Test*.
+
+~~~php
+	public function test_index_logged_in()
+	{
+		$this->request->setCallablePreConstructor(
+			function () {
+				// Get mock object
+				$auth = $this->getDouble(
+					'Ion_auth', ['logged_in' => TRUE]
+				);
+				// Inject mock object
+				load_class_instance('ion_auth', $auth);
+			}
+		);
+
+		$output = $this->request('GET', 'auth_check_in_construct');
+		$this->assertContains('You are logged in.', $output);
+	}
+~~~
+
+See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Auth_check_in_construct.php).
+
 #### Ajax Request
 
 You can use [$this->ajaxRequest()](FunctionAndClassReference.md#testcaseajaxrequestmethod-argv-params---callable--null) method in *CI PHPUnit Test*.


### PR DESCRIPTION
Now (v0.4.0) we can't write tests for a controller like below:

~~~php
<?php

class Auth_check_in_construct extends CI_Controller
{
	public function __construct()
	{
		parent::__construct();

		$this->load->library('session');
		if ($this->session->userdata('login') !== 'OK')
		{
			$this->load->helper('url');
			redirect('auth/login');
		}
	}

	public function index()
	{
		echo 'You are logged in.';
	}
}
~~~

Because we can't inject `session` object into the controller constructor.
This PR enables it.

But it seems the name `setCallablePreConstructor()` is not good. To begin with, `setCallable()` might be not good.

Should we rename `setCallable()`? Then, what name is good?
Any good idea?