### PR TITLE
Add functionality to patch exit() on the fly

### DIFF
--- a/application/tests/TestCase.php
+++ b/application/tests/TestCase.php
@@ -2,5 +2,5 @@
 
 class TestCase extends CIPHPUnitTestCase
 {
-	
+	public static $enable_patcher = false;
 }

--- a/application/tests/_ci_phpunit_test/exceptions/CIPHPUnitTestExitException.php
+++ b/application/tests/_ci_phpunit_test/exceptions/CIPHPUnitTestExitException.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+class CIPHPUnitTestExitException extends RuntimeException
+{
+	public $file;
+	public $line;
+	public $class;
+	public $method;
+	public $exit_status;
+}
+
+function exit_($status = null)
+{
+	$trace = debug_backtrace();
+	$file = $trace[0]['file'];
+	$line = $trace[0]['line'];
+	$class = isset($trace[1]['class']) ? $trace[1]['class'] : null;
+	$method = $trace[1]['function'];
+
+	if ($class === null)
+	{
+		$message = 'exit() called in ' . $method . '() function';
+	}
+	else
+	{
+		$message = 'exit() called in ' . $class . '::' . $method . '()';
+	}
+	
+
+	$exception = new CIPHPUnitTestExitException($message);
+	$exception->file = $file;
+	$exception->line = $line;
+	$exception->class = $class;
+	$exception->method = $method;
+	$exception->exit_status = $status;
+
+	throw $exception;
+}

--- a/application/tests/_ci_phpunit_test/patcher/CIPHPUnitTestIncludeStream.php
+++ b/application/tests/_ci_phpunit_test/patcher/CIPHPUnitTestIncludeStream.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+/**
+ * Copyright for Original Code
+ * 
+ * @author     Ignas Rudaitis <ignas.rudaitis@gmail.com>
+ * @copyright  2010-2015 Ignas Rudaitis
+ * @license    http://www.opensource.org/licenses/mit-license.html
+ * @link       http://antecedent.github.com/patchwork
+ * 
+ * @see        https://github.com/antecedent/patchwork/blob/1.3.4/src/Preprocessor/Stream.php
+ */
+
+class CIPHPUnitTestIncludeStream
+{
+	const STREAM_OPEN_FOR_INCLUDE = 128;
+
+	protected static $protocols = array('file', 'phar');
+
+	public $context;
+	public $resource;
+
+	public static function wrap()
+	{
+		foreach (static::$protocols as $protocol) {
+			stream_wrapper_unregister($protocol);
+			stream_wrapper_register($protocol, get_called_class());
+		}
+	}
+
+	public static function unwrap()
+	{
+		foreach (static::$protocols as $protocol) {
+			stream_wrapper_restore($protocol);
+		}
+	}
+
+	protected function shouldPreprocess($path)
+	{
+		return CIPHPUnitTestPatchPathChecker::check($path);
+	}
+
+	protected function preprocessAndOpen($path)
+	{
+		return CIPHPUnitTestPatcher::patch($path);
+	}
+
+	public function stream_open($path, $mode, $options, &$openedPath)
+	{
+		$this->unwrap();
+		$including = (bool) ($options & self::STREAM_OPEN_FOR_INCLUDE);
+		if ($including && $this->shouldPreprocess($path)) {
+			$this->resource = $this->preprocessAndOpen($path);
+			$this->wrap();
+			return true;
+		}
+		if (isset($this->context)) {
+			$this->resource = fopen($path, $mode, $options, $this->context);
+		} else {
+			$this->resource = fopen($path, $mode, $options);
+		}
+		$this->wrap();
+		return $this->resource !== false;
+	}
+
+	public function stream_close()
+	{
+		return fclose($this->resource);
+	}
+
+	public function stream_eof()
+	{
+		return feof($this->resource);
+	}
+
+	public function stream_flush()
+	{
+		return fflush($this->resource);
+	}
+
+	public function stream_read($count)
+	{
+		return fread($this->resource, $count);
+	}
+
+	public function stream_seek($offset, $whence = SEEK_SET)
+	{
+		return fseek($this->resource, $offset, $whence) === 0;
+	}
+
+	public function stream_stat()
+	{
+		return fstat($this->resource);
+	}
+
+	public function stream_tell()
+	{
+		return ftell($this->resource);
+	}
+
+	public function url_stat($path, $flags)
+	{
+		$this->unwrap();
+		if ($flags & STREAM_URL_STAT_QUIET) {
+			set_error_handler(function() {});
+		}
+		$result = stat($path);
+		if ($flags & STREAM_URL_STAT_QUIET) {
+			restore_error_handler();
+		}
+		$this->wrap();
+		return $result;
+	}
+
+	public function dir_closedir()
+	{
+		closedir($this->resource);
+		return true;
+	}
+
+	public function dir_opendir($path, $options)
+	{
+		$this->unwrap();
+		if (isset($this->context)) {
+			$this->resource = opendir($path, $this->context);
+		} else {
+			$this->resource = opendir($path);
+		}
+		$this->wrap();
+		return $this->resource !== false;
+	}
+
+	public function dir_readdir()
+	{
+		return readdir($this->resource);
+	}
+
+	public function dir_rewinddir()
+	{
+		rewinddir($this->resource);
+		return true;
+	}
+
+	public function mkdir($path, $mode, $options)
+	{
+		$this->unwrap();
+		if (isset($this->context)) {
+			$result = mkdir($path, $mode, $options, $this->context);
+		} else {
+			$result = mkdir($path, $mode, $options);
+		}
+		$this->wrap();
+		return $result;
+	}
+
+	public function rename($path_from, $path_to)
+	{
+		$this->unwrap();
+		if (isset($this->context)) {
+			$result = rename($path_from, $path_to, $this->context);
+		} else {
+			$result = rename($path_from, $path_to);
+		}
+		$this->wrap();
+		return $result;
+	}
+
+	public function rmdir($path, $options)
+	{
+		$this->unwrap();
+		if (isset($this->context)) {
+			$result = rmdir($path, $this->context);
+		} else {
+			$result = rmdir($path);
+		}
+		$this->wrap();
+		return $result;
+	}
+
+	public function stream_cast($cast_as)
+	{
+		return $this->resource;
+	}
+
+	public function stream_lock($operation)
+	{
+		return flock($this->resource, $operation);
+	}
+
+	public function stream_set_option($option, $arg1, $arg2)
+	{
+		switch ($option) {
+			case STREAM_OPTION_BLOCKING:
+				return stream_set_blocking($this->resource, $arg1);
+			case STREAM_OPTION_READ_TIMEOUT:
+				return stream_set_timeout($this->resource, $arg1, $arg2);
+			case STREAM_OPTION_WRITE_BUFFER:
+				return stream_set_write_buffer($this->resource, $arg1);
+			case STREAM_OPTION_READ_BUFFER:
+				return stream_set_read_buffer($this->resource, $arg1);
+		}
+	}
+
+	public function stream_write($data)
+	{
+		return fwrite($this->resource, $data);
+	}
+
+	public function unlink($path)
+	{
+		$this->unwrap();
+		if (isset($this->context)) {
+			$result = unlink($path, $this->context);
+		} else {
+			$result = unlink($path);
+		}
+		$this->wrap();
+		return $result;
+	}
+
+	public function stream_metadata($path, $option, $value)
+	{
+		$this->unwrap();
+		switch ($option) {
+			case STREAM_META_TOUCH:
+				if (empty($value)) {
+					$result = touch($path);
+				} else {
+					$result = touch($path, $value[0], $value[1]);
+				}
+				break;
+			case STREAM_META_OWNER_NAME:
+			case STREAM_META_OWNER:
+				$result = chown($path, $value);
+				break;
+			case STREAM_META_GROUP_NAME:
+			case STREAM_META_GROUP:
+				$result = chgrp($path, $value);
+				break;
+			case STREAM_META_ACCESS:
+				$result = chmod($path, $value);
+				break;
+		}
+		$this->wrap();
+		return $result;
+	}
+
+	public function stream_truncate($new_size)
+	{
+		return ftruncate($this->resource, $new_size);
+	}
+}

--- a/application/tests/_ci_phpunit_test/patcher/CIPHPUnitTestPatchPathChecker.php
+++ b/application/tests/_ci_phpunit_test/patcher/CIPHPUnitTestPatchPathChecker.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+class CIPHPUnitTestPatchPathChecker
+{
+	private static $whitelist_dir = [];
+	private static $blacklist_dir = [];
+
+	public static function setWhitelistDir(array $dir)
+	{
+		self::$whitelist_dir = $dir;
+	}
+
+	public static function setBlacklistDir(array $dir)
+	{
+		self::$blacklist_dir = $dir;
+	}
+
+	public static function check($path)
+	{
+		// Whitelist first
+		$is_white = false;
+		foreach (self::$whitelist_dir as $white_dir) {
+			$len = strlen($white_dir);
+			if (substr($path, 0, $len) === $white_dir)
+			{
+				$is_white = true;
+			}
+		}
+		if ($is_white === false)
+		{
+			return false;
+		}
+
+		// Then blacklist
+		foreach (self::$blacklist_dir as $black_dir) {
+			$len = strlen($black_dir);
+			if (substr($path, 0, $len) === $black_dir)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/application/tests/_ci_phpunit_test/patcher/CIPHPUnitTestPatcher.php
+++ b/application/tests/_ci_phpunit_test/patcher/CIPHPUnitTestPatcher.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+class CIPHPUnitTestPatcher
+{
+	private static $cache_dir;
+	private static $load_patchers = false;
+	private static $patcher_classnames = [];
+
+	public static function setCacheDir($dir)
+	{
+		self::$cache_dir = $dir;
+		self::createDir($dir);
+		self::loadPatchers();
+	}
+
+	protected static function createDir($dir)
+	{
+		if (! is_dir($dir))
+		{
+			if (! mkdir($dir, 0777, true))
+			{
+				throw new RuntimeException('Failed to create folder: ' . $dir);
+			}
+		}
+	}
+
+	/**
+	 * @param string $path original source file path
+	 * @return boolean
+	 */
+	protected static function hasValidCache($path)
+	{
+		$cache_file = self::getCacheFilePath($path);
+
+		if (
+			is_readable($cache_file) && filemtime($cache_file) > filemtime($path)
+		)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	protected static function getCacheFilePath($path)
+	{
+		$root = realpath(APPPATH . '../');
+		$len = strlen($root);
+		$relative_path = substr($path, $len);
+		return self::$cache_dir . $relative_path;
+	}
+
+	public static function patch($path)
+	{
+		if (self::$cache_dir === null)
+		{
+			throw new LogicException('You have to set $cache_dir');
+		}
+
+		// Check cache file
+		if (self::hasValidCache($path))
+		{
+			return fopen(self::getCacheFilePath($path), 'r');
+		}
+
+		$source = file_get_contents($path);
+
+		list($new_source, $patched) = self::execPatchers($source);
+
+		// Write to cache file
+		self::writeCacheFile($path, $new_source);
+
+		$resource = fopen('php://memory', 'rb+');
+		fwrite($resource, $new_source);
+		rewind($resource);
+		return $resource;
+	}
+
+	/**
+	 * @param string $path   original source file path
+	 * @param string $source source code
+	 */
+	protected static function writeCacheFile($path, $source)
+	{
+		$cache_file = self::getCacheFilePath($path);
+		$dir = dirname($cache_file);
+		self::createDir($dir);
+		file_put_contents($cache_file, $source);
+	}
+
+	protected static function loadPatchers()
+	{
+		if (self::$load_patchers)
+		{
+			return;
+		}
+
+		foreach (glob(__DIR__.'/patchers/*Patcher.php') as $patcher)
+		{
+			require $patcher;
+
+			$classname = basename($patcher, '.php');
+			self::$patcher_classnames[] = $classname;
+		}
+
+		self::$load_patchers = true;
+	}
+
+	protected static function execPatchers($source)
+	{
+		$patched = false;
+		foreach (self::$patcher_classnames as $classname)
+		{
+			list($source, $patched_this) = $classname::patch($source);
+			$patched = $patched || $patched_this;
+		}
+
+		return [
+			$source,
+			$patched,
+		];
+	}
+}

--- a/application/tests/_ci_phpunit_test/patcher/patchers/CIPHPUnitTestExitPatcher.php
+++ b/application/tests/_ci_phpunit_test/patcher/patchers/CIPHPUnitTestExitPatcher.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+class CIPHPUnitTestExitPatcher
+{
+	public static function patch($source)
+	{
+		$tokens = token_get_all($source);
+
+		$patched = false;
+		$new_source = '';
+		$i = -1;
+
+		foreach ($tokens as $token) {
+			$i++;
+			if (is_string($token))
+			{
+				$new_source .= $token;
+			}
+			elseif ($token[0] === T_EXIT)
+			{
+				if ($tokens[$i+1] === ';')
+				{
+					$new_source .= 'exit_()';
+				}
+				else
+				{
+					$new_source .= 'exit_';
+				}
+				$patched = true;
+			}
+			else
+			{
+				$new_source .= $token[1];
+			}
+		}
+
+		return [
+			$new_source,
+			$patched,
+		];
+	}
+}

--- a/docs/third_party_licenses/Patchwork_LICENSE.md
+++ b/docs/third_party_licenses/Patchwork_LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2010-2014 Ignas Rudaitis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
When a unit test exercises code that contains `exit()` or `die()` statement, the execution of the whole test suite is aborted.

If you set `TestCase::$enable_patcher` `true`, you can make all `exit()` and `die()` throw a `CIPHPUnitTestExitException` instead of quitting phpunit.

If a controller is like below:
~~~php
	public function index()
	{
		$this->output
			->set_status_header(200)
			->set_content_type('application/json', 'utf-8')
			->set_output(json_encode(['foo' => 'bar']))
			->_display();
		exit;
	}
~~~

A test could be:
~~~php
	public function test_index()
	{
		try {
			$this->request('GET', 'welcome/index');
		} catch (CIPHPUnitTestExitException $e) {
			$output = ob_get_clean();
		}
		$this->assertContains('{"foo":"bar"}', $output);
	}
~~~

This functionality is only to rescue legacy codes. I recommend not to use `exit()` in your code at all.
