### PR TITLE
Replace redirect() by default

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -31,8 +31,8 @@ class CIPHPUnitTest
 		// Load new functions of CIPHPUnitTest
 		require __DIR__ . '/functions.php';
 
-		// Replace Loader
 		self::replaceLoader();
+		self::replaceHelpers();
 
 		// Load autoloader for CIPHPUnitTest
 		require __DIR__ . '/autoloader.php';
@@ -82,6 +82,16 @@ class CIPHPUnitTest
 			require $my_loader_file;
 		}
 		self::loadLoader();
+	}
+
+	protected static function replaceHelpers()
+	{
+		$my_helper_file = APPPATH . 'helpers/' . config_item('subclass_prefix') . 'url_helper.php';
+		if (file_exists($my_helper_file))
+		{
+			require $my_helper_file;
+		}
+		require __DIR__ . '/replacing/helpers/url_helper.php';
 	}
 
 	protected static function loadCIPHPUnitTestClasses()

--- a/application/tests/_ci_phpunit_test/replacing/helpers/url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/url_helper.php
@@ -50,53 +50,56 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 // ------------------------------------------------------------------------
 
-function redirect($uri = '', $method = 'auto', $code = NULL)
+if ( ! function_exists('redirect'))
 {
-	if ( ! preg_match('#^(\w+:)?//#i', $uri))
+	function redirect($uri = '', $method = 'auto', $code = NULL)
 	{
-		$uri = site_url($uri);
-	}
-
-	// IIS environment likely? Use 'refresh' for better compatibility
-	if ($method === 'auto' && isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== FALSE)
-	{
-		$method = 'refresh';
-	}
-	elseif ($method !== 'refresh' && (empty($code) OR ! is_numeric($code)))
-	{
-		if (isset($_SERVER['SERVER_PROTOCOL'], $_SERVER['REQUEST_METHOD']) && $_SERVER['SERVER_PROTOCOL'] === 'HTTP/1.1')
+		if ( ! preg_match('#^(\w+:)?//#i', $uri))
 		{
-			$code = ($_SERVER['REQUEST_METHOD'] !== 'GET')
-				? 303	// reference: http://en.wikipedia.org/wiki/Post/Redirect/Get
-				: 307;
+			$uri = site_url($uri);
+		}
+
+		// IIS environment likely? Use 'refresh' for better compatibility
+		if ($method === 'auto' && isset($_SERVER['SERVER_SOFTWARE']) && strpos($_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== FALSE)
+		{
+			$method = 'refresh';
+		}
+		elseif ($method !== 'refresh' && (empty($code) OR ! is_numeric($code)))
+		{
+			if (isset($_SERVER['SERVER_PROTOCOL'], $_SERVER['REQUEST_METHOD']) && $_SERVER['SERVER_PROTOCOL'] === 'HTTP/1.1')
+			{
+				$code = ($_SERVER['REQUEST_METHOD'] !== 'GET')
+					? 303	// reference: http://en.wikipedia.org/wiki/Post/Redirect/Get
+					: 307;
+			}
+			else
+			{
+				$code = 302;
+			}
+		}
+
+		switch ($method)
+		{
+			case 'refresh':
+				header('Refresh:0;url='.$uri);
+				break;
+			default:
+				header('Location: '.$uri, TRUE, $code);
+				break;
+		}
+
+		if (ENVIRONMENT !== 'testing')
+		{
+			exit;
 		}
 		else
 		{
-			$code = 302;
+			while (ob_get_level() > 1)
+			{
+				ob_end_clean();
+			}
+
+			throw new CIPHPUnitTestRedirectException('Redirect to ' . $uri, $code);
 		}
-	}
-
-	switch ($method)
-	{
-		case 'refresh':
-			header('Refresh:0;url='.$uri);
-			break;
-		default:
-			header('Location: '.$uri, TRUE, $code);
-			break;
-	}
-
-	if (ENVIRONMENT !== 'testing')
-	{
-		exit;
-	}
-	else
-	{
-		while (ob_get_level() > 1)
-		{
-			ob_end_clean();
-		}
-
-		throw new CIPHPUnitTestRedirectException('Redirect to ' . $uri, $code);
 	}
 }

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -48,11 +48,11 @@ If you don't know well about config files and environments, see [CodeIgniter Use
 
 ### Can and Can't
 
-*CI PHPUnit Test* does not want to modify CodeIgniter core files. The more you modify core, the more you get difficulities when you update CodeIgniter.
+*CI PHPUnit Test* does not want to modify CodeIgniter files. The more you modify them, the more you get difficulities when you update CodeIgniter.
 
 In fact, it uses a modified class and a few functions. But I try to modify as little as possible.
 
-The functions and the class which are modified:
+The core functions and a class which are modified:
 
 * function `load_class()`
 * function `is_loaded()`
@@ -62,7 +62,11 @@ The functions and the class which are modified:
 * function `set_status_header()`
 * class `CI_Loader`
 
-They are in `tests/_ci_phpunit_test/replacing` folder.
+and a helper which is modified:
+
+* function `redirect()` in URL helper
+
+All of them are in `tests/_ci_phpunit_test/replacing` folder.
 
 And *CI PHPUnit Test* adds a property dynamically:
 
@@ -84,7 +88,7 @@ If your MY_Loader overrides the above methods, probably *CI PHPUnit Test* does n
 
 When a test exercises code that contains `exit()` or `die()` statement, the execution of the whole test suite is aborted.
 
-For example, if you use URL helper `redirect()` function in your application code, your testing ends with it.
+For example, if you write `exit()` in your controller code, your testing ends with it.
 
 I recommend you not to use `exit()` or `die()` in your code.
 
@@ -136,9 +140,7 @@ And *CI PHPUnit Test* has special [show_error() and show_404()](#show_error-and-
 
 **`redirect()`**
 
-Speaking of `redirect()`, I put a sample [MY_url_helper.php](https://github.com/kenjis/ci-phpunit-test/blob/master/application/helpers/MY_url_helper.php).
-
-If you use the `MY_url_helper.php`, you can easily test controllers that contain `redirect()`. See [`redirect()`](#redirect) for details.
+*CI PHPUnit Test* replaces `redirect()` function in URL helper. Using it, you can easily test controllers that contain `redirect()`. See [`redirect()`](#redirect) for details.
 
 #### Reset CodeIgniter object
 
@@ -406,9 +408,11 @@ See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/m
 
 #### `redirect()`
 
-I recommend to use this [MY_url_helper.php](../application/helpers/MY_url_helper.php).
+By default, *CI PHPUnit Test* replaces `redirect()` function in URL helper. Using it, you can easily test controllers that contain `redirect()`.
 
-If you use it, you can write tests like this:
+But you could still override `redirect()` using your `MY_url_helper.php`. If you place `MY_url_helper.php`, your `redirect()` will be used.
+
+If you use `redirect()` in *CI PHPUnit Test*, you can write tests like this:
 
 ~~~php
 	public function test_index()


### PR DESCRIPTION
* By default, *ci-phpunit-test* replaces `redirect()` helper
* But if you have `MY_url_helper.php` (and `redirect()` in it), your `redirect()` will be used
