### PR TITLE
Add $this->resetInstance() to set up for model testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To generate coverage report, Xdebug is needed.
 
 ## How to Write Tests
 
-As an example, a test case class for Inventory_model would be as follows:
+As an example, a test case class for `Inventory_model` would be as follows:
 
 ~~~php
 <?php
@@ -115,7 +115,7 @@ class Inventory_model_test extends TestCase
 {
     public function setUp()
     {
-        $this->CI =& get_instance();
+        $this->resetInstance();
         $this->CI->load->model('Inventory_model');
         $this->obj = $this->CI->Inventory_model;
     }

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -23,6 +23,11 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	protected $double;
 
 	/**
+	 * @var CI_Controller CodeIgniter instance
+	 */
+	protected $CI;
+
+	/**
 	 * Constructs a test case with the given name.
 	 *
 	 * @param string $name
@@ -45,6 +50,16 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 			'index.php',
 		];
 		$_SERVER['argc'] = 1;
+	}
+
+	/**
+	 * Reset CodeIgniter instance and assign new CodeIgniter instance as $this->CI
+	 */
+	public function resetInstance()
+	{
+		reset_instance();
+		new CI_Controller();
+		$this->CI =& get_instance();
 	}
 
 	public function tearDown()

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -10,6 +10,7 @@
 
 * Monkey Patching on functions. See [How to Write Tests](https://github.com/kenjis/ci-phpunit-test/blob/master/docs/HowToWriteTests.md#patching-functions).
 * Monkey Patching on methods in user-defined classes. See [How to Write Tests](https://github.com/kenjis/ci-phpunit-test/blob/master/docs/HowToWriteTests.md#patching-methods-in-user-defined-classes).
+* `$this->resetInstance()` for better model testing. See [#40](https://github.com/kenjis/ci-phpunit-test/pull/40).
 
 ### Removed
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -12,6 +12,7 @@ version: **master** |
 - [*function* `set_is_cli($return)`](#function-set_is_clireturn)
 - [*function* `load_class_instance($classname, $instance)`](#function-load_class_instanceclassname-instance)
 - [*class* TestCase](#class-testcase)
+	- [`TestCase::resetInstance()`](#testcaseresetinstance)
 	- [`TestCase::request($method, $argv, $params = [], $callable = null)`](#testcaserequestmethod-argv-params---callable--null)
 		- [`request->setCallable()`](#request-setcallable)
 		- [`request->setCallablePreConstructor()`](#request-setcallablepreconstructor)
@@ -46,6 +47,8 @@ $controller = new Welcome();
 $this->CI =& get_instance();
 ~~~
 
+Normally, you don't have to use this function. Use [`TestCase::resetInstance()`](#testcaseresetinstance) method instead.
+
 ### *function* `set_is_cli($return)`
 
 | param   | type | description         |
@@ -77,6 +80,38 @@ load_class_instance('email', $email);
 ~~~
 
 ### *class* TestCase
+
+#### `TestCase::resetInstance()`
+
+Reset CodeIgniter instance and assign new CodeIgniter instance as `$this->CI`.
+
+~~~php
+public function setUp()
+{
+	$this->resetInstance();
+	$this->CI->load->model('Category_model');
+	$this->obj = $this->CI->Category_model;
+}
+~~~
+
+**Note:** When you call `$this->request()`, you don't have to use this method. Because `$this->request()` resets CodeIgniter instance internally.
+
+**Upgrade Note for v0.6.0**
+
+Before v0.6.0, we write `setUp()` method like this:
+
+~~~php
+public function setUp()
+{
+	$this->CI =& get_instance();
+	$this->CI->load->model('Category_model');
+	$this->obj = $this->CI->Category_model;
+}
+~~~
+
+When you use the way, you use the same CodeIgniter instance and the same `Category_model` instance in every test method.
+
+In contrast, if you use `$this->resetInstance()`, it resets CodeIgniter instance and `Category_model`. So you use new CodeIgniter instance and new `Category_model` instance in every test method.
 
 #### `TestCase::request($method, $argv, $params = [], $callable = null)`
 

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -203,7 +203,7 @@ If you don't know well about PHPUnit Mock Objects, see [Test Doubles](https://ph
 ~~~php
 	public function setUp()
 	{
-		$this->CI =& get_instance();
+		$this->resetInstance();
 		$this->CI->load->model('Category_model');
 		$this->obj = $this->CI->Category_model;
 	}
@@ -254,14 +254,10 @@ If you don't know well about PHPUnit Mock Objects, see [Test Doubles](https://ph
 		foreach ($list as $category) {
 			$this->assertEquals($expected[$category->id], $category->name);
 		}
-
-		// Reset CI object for next test case, unless property db won't work
-		reset_instance();
-		new CI_Controller();
 	}
 ~~~
 
-**Note:** Once you have replaced CodeIgniter object's property with your mock, the mock remains until you call `reset_instance()` and instantiate a controller.
+[$this->resetInstance()](FunctionAndClassReference.md#testcaseresetinstance) method in *CI PHPUnit Test* is a helper method to reset CodeIgniter instance and assign new CodeIgniter instance as `$this->CI`.
 
 See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/models/Category_model_mocking_db_test.php).
 


### PR DESCRIPTION
When we test models, the current practice is like this:
~~~php
    public function setUp()
    {
        $this->CI =& get_instance();
        $this->CI->load->model('Inventory_model');
        $this->obj = $this->CI->Inventory_model;
    }
~~~

The `setUp()` method gives the same `Inventory_model` object in every test method. Because `$this->CI->load->model()` creates new instance only once.

But normally we do like this when we use PHPUnit:
~~~php
    public function setUp()
    {
        $this->obj = new Inventory_model();
    }
~~~

`$this->obj` is a new instance in every test method.

This `$this->resetInstance()` method resets controller and make `$this->CI`. So if we write like this:
~~~php
	public function setUp()
	{
		$this->resetInstance();
		$this->CI->load->model('Category_model');
		$this->obj = $this->CI->Category_model;
	}
~~~

Then `$this->obj` is a new instance in every test method.

And if we use this on every non-controller tests, even when we inject mock object, we don't have to reset controller like this: https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/models/Category_model_mocking_db_test.php#L59-L61

