### PR TITLE
Add functionality to limit scope for function patching

### DIFF
--- a/application/tests/_ci_phpunit_test/patcher/MonkeyPatch.php
+++ b/application/tests/_ci_phpunit_test/patcher/MonkeyPatch.php
@@ -21,10 +21,11 @@ class MonkeyPatch
 	 * 
 	 * @param string $function     function name
 	 * @param mixed  $return_value return value
+	 * @param string $class_name   class::method to apply this patch
 	 */
-	public static function patchFunction($function, $return_value)
+	public static function patchFunction($function, $return_value, $class_method = null)
 	{
-		Proxy::patch__($function, $return_value);
+		Proxy::patch__($function, $return_value, $class_method);
 	}
 
 	/**

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -28,7 +28,7 @@ version: **master** |
 	- [`TestCase::warningOff()`](#testcasewarningoff)
 	- [`TestCase::warningOn()`](#testcasewarningon)
 - [*class* MonkeyPatch](#class-monkeypatch)
-	- [`MonkeyPatch::patchFunction($function, $return_value)`](#monkeypatchpatchfunctionfunction-return_value)
+	- [`MonkeyPatch::patchFunction($function, $return_value, $class_method)`](#monkeypatchpatchfunctionfunction-return_value-class_method)
 	- [`MonkeyPatch::resetFunctions()`](#monkeypatchresetfunctions)
 	- [`MonkeyPatch::patchMethod($classname, $params)`](#monkeypatchpatchmethodclassname-params)
 	- [`MonkeyPatch::resetMethods()`](#monkeypatchresetmethods)
@@ -377,18 +377,19 @@ Restore error reporting.
 
 To use this class, you have to enable monkey patching. See [How to Write Tests](HowToWriteTests.md#monkey-patching).
 
-#### `MonkeyPatch::patchFunction($function, $return_value)`
+#### `MonkeyPatch::patchFunction($function, $return_value, $class_method)`
 
-| param         | type   | description             |
-|---------------|--------|-------------------------|
-|`$function`    | string | function name to patch  |
-|`$return_value`| mixed  | return value / callback |
+| param         | type   | description                                    |
+|---------------|--------|------------------------------------------------|
+|`$function`    | string | function name to patch                         |
+|`$return_value`| mixed  | return value / callback                        |
+|`$class_method`| string | class::method or classname to apply this patch |
 
 Replace function on the fly.
 
-This can't replace functions which has parameters passed by reference.
+If `$class_method` is present, the patch is applied to the functions only in the class method or in the class.
 
-And it can't and doesn't replace some functions. See [FunctionPatcher::$blacklist](https://github.com/kenjis/ci-phpunit-test/blob/master/application/tests/_ci_phpunit_test/patcher/Patcher/FunctionPatcher.php#L33) for details.
+There are some known limitations. See [How to Write Tests](HowToWriteTests.md#patching-functions) for details.
 
 #### `MonkeyPatch::resetFunctions()`
 

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -661,15 +661,17 @@ So by default we can replace only a dozen pre-defined functions in [FunctionPatc
 ~~~php
 	public function test_index()
 	{
-		MonkeyPatch::patchFunction('mt_rand', 100);
+		MonkeyPatch::patchFunction('mt_rand', 100, 'Welcome::index');
 		$output = $this->request('GET', 'welcome/index');
 		$this->assertContains('100', $output);
 	}
 ~~~
 
-[MonkeyPatch::patchFunction()](FunctionAndClassReference.md#monkeypatchpatchfunctionfunction-return_value) replaces PHP native function `mt_rand()`, and it will return `100` in the test method.
+[MonkeyPatch::patchFunction()](FunctionAndClassReference.md#monkeypatchpatchfunctionfunction-return_value-class_method) replaces PHP native function `mt_rand()` in `Welcome::index` method, and it will return `100` in the test method.
 
-**Note:** If you replace a function, all the functions (located in `exclude_paths`) called in the test method will be replaced. So, for example, a function in CodeIgniter code might be replaced and it results in unexpected outcome. You could change return value of patched function using PHP closure. See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Patching_on_function_test.php#L50-L70).
+You could change return value of patched function using PHP closure. See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Patching_on_function_test.php#L50-L70).
+
+**Note:** If you call `MonkeyPatch::patchFunction()` without 3rd argument, all the functions (located in `include_paths` and not in `exclude_paths`) called in the test method will be replaced. So, for example, a function in CodeIgniter code might be replaced and it results in unexpected outcome. 
 
 If you want to patch other functions, you can add them to [functions_to_patch](https://github.com/kenjis/ci-phpunit-test/blob/master/application/tests/Bootstrap.php#L318) in `MonkeyPatchManager::init()`.
 


### PR DESCRIPTION
Function patching is very strong, but replacing global function is danger.

This PR adds 3rd parameter to limit scope.

~~~
MonkeyPatch::patchFunction('mt_rand', 100, 'Welcome::index');
~~~

`mt_rand` only in `Welcome::index()` will be replaced.
