### PR TITLE
Improve testing REST controllers

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -233,12 +233,33 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Set Expected Redirect
+	 * Asserts HTTP response header
 	 * 
-	 * This method needs <https://github.com/kenjis/ci-phpunit-test/blob/master/application/helpers/MY_url_helper.php>.
+	 * @param string $name  header name
+	 * @param string $value header value
+	 */
+	public function assertResponseHeader($name, $value)
+	{
+		$CI =& get_instance();
+		$actual = $CI->output->get_header($name);
+
+		if ($actual === null)
+		{
+			$this->fail("The '$name' header is not set.\nNote that `assertResponseHeader()` can only assert headers set by `\$this->output->set_header()`");
+		}
+
+		$this->assertEquals(
+			$value,
+			$actual,
+			"The '$name' header is not '$value' but '$actual'."
+		);
+	}
+
+	/**
+	 * Asserts Redirect
 	 * 
 	 * @param string $uri  URI to redirect
-	 * @param int    $code Response Code
+	 * @param int    $code response code
 	 */
 	public function assertRedirect($uri, $code = null)
 	{

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -38,6 +38,31 @@ class CIPHPUnitTestRequest
 	protected $bc_mode_throw_PHPUnit_Framework_Exception = false;
 
 	/**
+	 * Set HTTP request header
+	 * 
+	 * @param string $name  header name
+	 * @param string $value value
+	 */
+	public function setHeader($name, $value)
+	{
+		$normalized_name = str_replace('-', '_', strtoupper($name));
+
+		if (
+			$normalized_name === 'CONTENT_LENGTH' 
+			|| $normalized_name === 'CONTENT_TYPE'
+		)
+		{
+			$key = $normalized_name;
+		}
+		else
+		{
+			$key = 'HTTP_' . $normalized_name;
+		}
+
+		$_SERVER[$key] = $value;
+	}
+
+	/**
 	 * Set callable
 	 * 
 	 * @param callable $callable function to run after controller instantiation

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -5,6 +5,8 @@
 ### Added
 
 * Now `$this->request()` can create REST request more easily. See [#47](https://github.com/kenjis/ci-phpunit-test/pull/47).
+* `$this->request->setHeader()` to set HTTP request header. See [#47](https://github.com/kenjis/ci-phpunit-test/pull/47).
+* `$this->assertResponseHeader()` to assert HTTP response header. See [#47](https://github.com/kenjis/ci-phpunit-test/pull/47).
 * Autoloading for libraries
 
 ### Removed

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Now `$this->request()` can create REST request more easily. See [#47](https://github.com/kenjis/ci-phpunit-test/pull/47).
 * Autoloading for libraries
 
 ### Removed

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -15,12 +15,14 @@ version: **master** |
 - [*class* TestCase](#class-testcase)
 	- [`TestCase::resetInstance()`](#testcaseresetinstance)
 	- [`TestCase::request($method, $argv, $params = [])`](#testcaserequestmethod-argv-params--)
+		- [`request->setHeader()`](#request-setheader)
 		- [`request->setCallable()`](#request-setcallable)
 		- [`request->setCallablePreConstructor()`](#request-setcallablepreconstructor)
 		- [`request->enableHooks()`](#request-enablehooks)
 	- [`TestCase::ajaxRequest($method, $argv, $params = [])`](#testcaseajaxrequestmethod-argv-params--)
 	- [`TestCase::assertResponseCode($code)`](#testcaseassertresponsecodecode)
 	- [`TestCase::assertRedirect($uri, $code = null)`](#testcaseassertredirecturi-code--null)
+	- [`TestCase::assertResponseHeader($name, $value)`](#testcaseassertresponseheadername-value)
 	- [`TestCase::getDouble($classname, $params)`](#testcasegetdoubleclassname-params)
 	- [`TestCase::verifyInvoked($mock, $method, $params)`](#testcaseverifyinvokedmock-method-params)
 	- [`TestCase::verifyInvokedOnce($mock, $method, $params)`](#testcaseverifyinvokedoncemock-method-params)
@@ -138,6 +140,14 @@ If you want to specify URI string:
 $output = $this->request('GET', 'products/shoes/show/123');
 ~~~
 
+##### `request->setHeader()`
+
+Set HTTP request header.
+
+~~~php
+$this->request->setHeader('Accept', 'application/csv');
+~~~
+
 ##### `request->setCallable()`
 
 Set function to run after controller instantiation.
@@ -197,6 +207,10 @@ The same as `TestCase::request()`, but this makes an Ajax request. This adds onl
 
 Check for a specific response code on your controller tests.
 
+~~~php
+$this->assertResponseCode(200);
+~~~
+
 #### `TestCase::assertRedirect($uri, $code = null)`
 
 | param   | type   | description      |
@@ -205,6 +219,27 @@ Check for a specific response code on your controller tests.
 |`$code`  | int    | HTTP status code |
 
 Check if `redirect()` is called on your controller tests.
+
+~~~php
+$this->assertRedirect('auth/login');
+~~~
+
+#### `TestCase::assertResponseHeader($name, $value)`
+
+| param   | type   | description  |
+|---------|--------|--------------|
+|`$name`  | string | header name  |
+|`$value` | string | header value |
+
+Check for a specific response header on your controller tests.
+
+~~~php
+$this->assertResponseHeader(
+	'Content-Type', 'application/csv; charset=utf-8'
+);
+~~~
+
+**Note:** This method can only assert headers set by `$this->output->set_header()` method.
 
 #### `TestCase::getDouble($classname, $params)`
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -187,7 +187,7 @@ $output = $this->request('GET', 'products/shoes/show/123');
 
 `returns` (string) output strings
 
-The same as `TestCase::request()`, but this makes a Ajax request. This adds only `$_SERVER['HTTP_X_REQUESTED_WITH']`.
+The same as `TestCase::request()`, but this makes an Ajax request. This adds only `$_SERVER['HTTP_X_REQUESTED_WITH']`.
 
 #### `TestCase::assertResponseCode($code)`
 
@@ -357,11 +357,11 @@ $this->verifyNeverInvoked(
 
 #### `TestCase::warningOff()`
 
-Turn off WARNING in error reporting.
+Turn off WARNING in PHP error reporting.
 
 #### `TestCase::warningOn()`
 
-Restore error reporting.
+Restore PHP error reporting.
 
 ### *class* MonkeyPatch
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -116,11 +116,11 @@ In contrast, if you use `$this->resetInstance()`, it resets CodeIgniter instance
 
 #### `TestCase::request($method, $argv, $params = [])`
 
-| param     | type         | description                                    |
-|-----------|--------------|------------------------------------------------|
-|`$method`  | string       | HTTP method                                    |
-|`$argv`    | array/string | controller, method [, arg1, ...] / URI string  |
-|`$params`  | array        | POST parameters / Query string                 |
+| param     | type         | description                                        |
+|-----------|--------------|----------------------------------------------------|
+|`$method`  | string       | HTTP method                                        |
+|`$argv`    | array/string | controller, method [, arg1, ...] / URI string      |
+|`$params`  | array/string | POST parameters or Query string / raw_input_stream |
 
 `returns` (string) output strings (view)
 
@@ -179,11 +179,11 @@ $output = $this->request('GET', 'products/shoes/show/123');
 
 #### `TestCase::ajaxRequest($method, $argv, $params = [])`
 
-| param     | type         | description                                    |
-|-----------|--------------|------------------------------------------------|
-|`$method`  | string       | HTTP method                                    |
-|`$argv`    | array/string | controller, method [, arg1, ...] / URI string  |
-|`$params`  | array        | POST parameters / Query string                 |
+| param     | type         | description                                        |
+|-----------|--------------|----------------------------------------------------|
+|`$method`  | string       | HTTP method                                        |
+|`$argv`    | array/string | controller, method [, arg1, ...] / URI string      |
+|`$params`  | array/string | POST parameters or Query string / raw_input_stream |
 
 `returns` (string) output strings
 

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -364,6 +364,28 @@ You can specify request method in 2nd argument of [$this->request()](FunctionAnd
 		);
 ~~~
 
+You can set request header with [$this->request->setHeader()](FunctionAndClassReference.md#request-setheader) method in *CI PHPUnit Test*. And you can confirm response header with [$this->assertResponseHeader()](FunctionAndClassReference.md#testcaseassertresponseheadername-value) method in *CI PHPUnit Test*.
+
+~~~php
+	public function test_users_get_id_with_http_accept_header()
+	{
+		$this->request->setHeader('Accept', 'application/csv');
+		$output = $this->request('GET', 'api/example/users/id/1');
+		$this->assertEquals(
+			'id,name,email,fact
+1,John,john@example.com,"Loves coding"
+',
+			$output
+		);
+		$this->assertResponseCode(200);
+		$this->assertResponseHeader(
+			'Content-Type', 'application/csv; charset=utf-8'
+		);
+	}
+~~~
+
+See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/api/Example_test.php).
+
 #### Ajax Request
 
 You can use [$this->ajaxRequest()](FunctionAndClassReference.md#testcaseajaxrequestmethod-argv-params--) method in *CI PHPUnit Test*.

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -890,7 +890,7 @@ class Example_test extends TestCase
 }
 ~~~
 
-And if you copy sample api controllers, you must change `require` statement to `require_one`:
+And if you copy sample api controllers, you must change `require` statement to `require_once`:
 
 ~~~diff
 --- a/application/controllers/api/Example.php

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -25,8 +25,9 @@ version: **master** |
 - [Controllers](#controllers)
 	- [Request to Controller](#request-to-controller)
 	- [Request to URI string](#request-to-uri-string)
-	- [Request and Use Mocks](#request-and-use-mocks)
+	- [REST Request](#rest-request)
 	- [Ajax Request](#ajax-request)
+	- [Request and Use Mocks](#request-and-use-mocks)
 	- [Examine DOM in Controller Output](#examine-dom-in-controller-output)
 	- [Controller with Authentication](#controller-with-authentication)
 	- [`redirect()`](#redirect)
@@ -347,6 +348,37 @@ See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/m
 
 See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/sub/Sub_test.php).
 
+#### REST Request
+
+You can specify request method in 2nd argument of [$this->request()](FunctionAndClassReference.md#testcaserequestmethod-argv-params--) method and request body in 3rd argument of `$this->request()`.
+
+~~~php
+		$output = $this->request(
+			'PUT', 'api/user', json_encode(['name' => 'mike'])
+		);
+~~~
+
+~~~php
+		$output = $this->request(
+			'DELETE', 'api/key', 'key=12345678'
+		);
+~~~
+
+#### Ajax Request
+
+You can use [$this->ajaxRequest()](FunctionAndClassReference.md#testcaseajaxrequestmethod-argv-params--) method in *CI PHPUnit Test*.
+
+~~~php
+	public function test_index_ajax_call()
+	{
+		$output = $this->ajaxRequest('GET', ['Ajax', 'index']);
+		$expected = '{"name": "John Smith", "age": 33}';
+		$this->assertEquals($expected, $output);
+	}
+~~~
+
+See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Ajax_test.php).
+
 #### Request and Use Mocks
 
 You can use [$this->request->setCallable()](FunctionAndClassReference.md#request-setcallable) method in *CI PHPUnit Test*. [$this->getDouble()](FunctionAndClassReference.md#testcasegetdoubleclassname-params) is a helper method in *CI PHPUnit Test*.
@@ -424,21 +456,6 @@ In this case, You can use [$this->request->setCallablePreConstructor()](Function
 **Note:** When you have never loaded a class with CodeIgniter loader, if you make mock object for the class, it may not work. If you have got error, please try to load it before getting mock object.
 
 See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Auth_check_in_construct_test.php).
-
-#### Ajax Request
-
-You can use [$this->ajaxRequest()](FunctionAndClassReference.md#testcaseajaxrequestmethod-argv-params--) method in *CI PHPUnit Test*.
-
-~~~php
-	public function test_index_ajax_call()
-	{
-		$output = $this->ajaxRequest('GET', ['Ajax', 'index']);
-		$expected = '{"name": "John Smith", "age": 33}';
-		$this->assertEquals($expected, $output);
-	}
-~~~
-
-See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/controllers/Ajax_test.php).
 
 #### Check Status Code
 


### PR DESCRIPTION
### 1. Set request body for REST request

If 3rd argument of `$this->request()` is string, ci-phpunit-test sets it to `CI_Input::$_raw_input_stream`.

You can write test like this:
~~~php
$output = $this->request('DELETE', 'api/key/index', 'key=12345678');
~~~

Before this PR, we have to write test like this:
~~~php
$this->request->setCallablePreConstructor(
	function () {
		$INPUT =& load_class('Input', 'core');
		CIPHPUnitTestReflection::setPrivateProperty(
			$INPUT,
			'_raw_input_stream',
			'key=12345678'
		);
	}
);
$output = $this->request('DELETE', 'api/key/index');
~~~

### 2. Set HTTP request header

Add method to set request header.

~~~php
$this->request->setHeader('Accept', 'application/csv');
~~~

### 3. Assert HTTP response header

Add method to assert response header.

~~~php
$this->assertResponseHeader(
	'Content-Type', 'application/csv; charset=utf-8'
);
~~~