### PR TITLE
Support PHP7

### DIFF
--- a/application/tests/_ci_phpunit_test/patcher/MonkeyPatchManager.php
+++ b/application/tests/_ci_phpunit_test/patcher/MonkeyPatchManager.php
@@ -266,6 +266,7 @@ class MonkeyPatchManager
 		}
 
 		require __DIR__ . '/Patcher/AbstractPatcher.php';
+		require __DIR__ . '/Patcher/Backtrace.php';
 
 		foreach (self::$patcher_list as $classname)
 		{

--- a/application/tests/_ci_phpunit_test/patcher/Patcher/Backtrace.php
+++ b/application/tests/_ci_phpunit_test/patcher/Patcher/Backtrace.php
@@ -27,6 +27,15 @@ class Backtrace
 		}
 		$offset = self::$map[$patcher];
 
+		// Supports PHP7 optimization
+		if (version_compare(PHP_VERSION, '6.0.0', '>'))
+		{
+			if ($backtrace[$offset]['function'] === '__callStatic')
+			{
+				$offset--;
+			}
+		}
+
 		$file = isset($backtrace[$offset]['file'])
 				? $backtrace[$offset]['file'] : null;
 		$line = isset($backtrace[$offset]['line'])

--- a/application/tests/_ci_phpunit_test/patcher/Patcher/Backtrace.php
+++ b/application/tests/_ci_phpunit_test/patcher/Patcher/Backtrace.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+namespace Kenjis\MonkeyPatch\Patcher;
+
+use LogicException;
+
+class Backtrace
+{
+	private static $map = [
+		'FunctionPatcher' => 1,
+		'MethodPatcher'   => 0,
+	];
+
+	public static function getInfo($patcher, $backtrace)
+	{
+		if (! isset(self::$map[$patcher]))
+		{
+			throw new LogicException("No such a patcher: $patcher");
+		}
+		$offset = self::$map[$patcher];
+
+		$file = isset($backtrace[$offset]['file'])
+				? $backtrace[$offset]['file'] : null;
+		$line = isset($backtrace[$offset]['line'])
+				? $backtrace[$offset]['line'] : null;
+
+		if (isset($backtrace[$offset+2]))
+		{
+			$class  = isset($backtrace[$offset+2]['class'])
+					? $backtrace[$offset+2]['class']
+					: null;
+			$function = $backtrace[$offset+2]['function'];
+		}
+		else
+		{
+			$class = null;
+			$function = null;
+		}
+
+		if (isset($class))
+		{
+			$method = $function;
+			$class_method = $class . '::' . $function;
+			$function = null;
+		}
+		else
+		{
+			$method = null;
+			$class_method = null;
+		}
+
+		return [
+			'file' => $file,
+			'line' => $line,
+			'class' => $class,
+			'method' => $method,
+			'class_method' => $class_method,
+			'function' => $function,
+		];
+	}
+}

--- a/application/tests/_ci_phpunit_test/patcher/Patcher/MethodPatcher/PatchManager.php
+++ b/application/tests/_ci_phpunit_test/patcher/Patcher/MethodPatcher/PatchManager.php
@@ -13,6 +13,7 @@ namespace Kenjis\MonkeyPatch\Patcher\MethodPatcher;
 class_alias('Kenjis\MonkeyPatch\Patcher\MethodPatcher\PatchManager', '__PatchManager__');
 
 use Kenjis\MonkeyPatch\MonkeyPatchManager;
+use Kenjis\MonkeyPatch\Patcher\Backtrace;
 use Kenjis\MonkeyPatch\InvocationVerifier;
 
 class PatchManager
@@ -47,13 +48,18 @@ class PatchManager
 		if (MonkeyPatchManager::$debug)
 		{
 			$trace = debug_backtrace();
-			$file = $trace[0]['file'];
-			$line = $trace[0]['line'];
+			$info = Backtrace::getInfo('MethodPatcher', $trace);
 			
-			if (isset($trace[2]))
+			$file = $info['file'];
+			$line = $info['line'];
+			
+			if (isset($info['class_method']))
 			{
-				$called_method = 
-					isset($trace[2]['class']) ? $trace[2]['class'].'::'.$trace[2]['function'].'()' : $trace[2]['function'].'()';
+				$called_method = $info['class_method'];
+			}
+			elseif (isset($info['function']))
+			{
+				$called_method = $info['function'];
 			}
 			else
 			{

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -4,6 +4,7 @@
 
 ### Others
 
+* Compatible with PHP 7.0.0-RC4
 * Update nikic/PHP-Parser to v1.4.1
 
 ## v0.8.1 (2015/10/01)


### PR DESCRIPTION
There are some `debug_backtrace()` BC breaks in PHP7.
Monkey patching does not work because of the BC break.
This PR supports PHP7.

See
* https://bugs.php.net/bug.php?id=70634
* https://github.com/php/php-src/blob/PHP-7.0/UPGRADING#L215 (not related with ci-phpunit-test)
