### PR TITLE
Fix wrong implementation of resetting CodeIgniter instance

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -132,12 +132,13 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	 * $email = $this->getDouble('CI_Email', ['send' => TRUE]);
 	 *
 	 * @param  string $classname
-	 * @param  array  $params    [method_name => return_value]
+	 * @param  array  $params             [method_name => return_value]
+	 * @param  bool   $enable_constructor enable constructor or not
 	 * @return object PHPUnit mock object
 	 */
-	public function getDouble($classname, $params)
+	public function getDouble($classname, $params, $enable_constructor = false)
 	{
-		return $this->double->getDouble($classname, $params);
+		return $this->double->getDouble($classname, $params, $enable_constructor);
 	}
 
 	/**

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -38,6 +38,7 @@ class CIPHPUnitTestDouble
 		$methods = array_keys($params);
 
 		$mock = $this->testCase->getMockBuilder($classname)
+			->disableOriginalConstructor()
 			->setMethods($methods)->getMock();
 
 		foreach ($params as $method => $return)

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -37,6 +37,10 @@ class CIPHPUnitTestDouble
 	{
 		$methods = array_keys($params);
 
+		// Added `disableOriginalConstructor()`, because if we call
+		// construnctor, it may call `$this->load->...` or other CodeIgniter
+		// methods in it. But we can't use them in
+		// `$this->request->setCallablePreConstructor()`
 		$mock = $this->testCase->getMockBuilder($classname)
 			->disableOriginalConstructor()
 			->setMethods($methods)->getMock();

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -21,6 +21,7 @@ class CIPHPUnitTestDouble
 	 * Get Mock Object
 	 *
 	 * $email = $this->getMockBuilder('CI_Email')
+	 *	->disableOriginalConstructor()
 	 *	->setMethods(['send'])
 	 *	->getMock();
 	 * $email->method('send')->willReturn(TRUE);
@@ -30,20 +31,24 @@ class CIPHPUnitTestDouble
 	 * $email = $this->getDouble('CI_Email', ['send' => TRUE]);
 	 *
 	 * @param  string $classname
-	 * @param  array  $params    [method_name => return_value]
+	 * @param  array  $params             [method_name => return_value]
+	 * @param  bool   $enable_constructor enable constructor or not
 	 * @return object PHPUnit mock object
 	 */
-	public function getDouble($classname, $params)
+	public function getDouble($classname, $params, $enable_constructor = false)
 	{
 		$methods = array_keys($params);
 
-		// Added `disableOriginalConstructor()`, because if we call
+		// `disableOriginalConstructor()` is the default, because if we call
 		// construnctor, it may call `$this->load->...` or other CodeIgniter
 		// methods in it. But we can't use them in
 		// `$this->request->setCallablePreConstructor()`
-		$mock = $this->testCase->getMockBuilder($classname)
-			->disableOriginalConstructor()
-			->setMethods($methods)->getMock();
+		$mock = $this->testCase->getMockBuilder($classname);
+		if (! $enable_constructor)
+		{
+			$mock->disableOriginalConstructor();
+		}
+		$mock = $mock->setMethods($methods)->getMock();
 
 		foreach ($params as $method => $return)
 		{

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestNullCodeIgniter.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestNullCodeIgniter.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Part of CI PHPUnit Test
+ *
+ * @author     Kenji Suzuki <https://github.com/kenjis>
+ * @license    MIT License
+ * @copyright  2015 Kenji Suzuki
+ * @link       https://github.com/kenjis/ci-phpunit-test
+ */
+
+/**
+ * Represents CodeIgniter instance is null
+ */
+class CIPHPUnitTestNullCodeIgniter
+{
+	public function __get($name)
+	{
+		throw new LogicException("CodeIgniter instance is not instantiated yet. You can't use `\$this->$name` at the moment. Please fix your test code.");
+	}
+}

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -33,7 +33,6 @@ class CIPHPUnitTestRequest
 	protected $callablePreConstructor;
 
 	protected $enableHooks = false;
-	protected $CI;
 	
 	/**
 	 * @var CI_Hooks
@@ -108,10 +107,6 @@ class CIPHPUnitTestRequest
 	 */
 	public function request($http_method, $argv, $params = [])
 	{
-		// We need this because if 404 route, no controller is created.
-		// But we need $this->CI->output->_status
-		$this->CI =& get_instance();
-
 		if (is_string($argv))
 		{
 			$argv = ltrim($argv, '/');
@@ -146,7 +141,8 @@ class CIPHPUnitTestRequest
 			{
 				set_status_header($e->getCode());
 			}
-			$this->CI->output->_status['redirect'] = $e->getMessage();
+			$CI =& get_instance();
+			$CI->output->_status['redirect'] = $e->getMessage();
 		}
 		// show_404()
 		catch (CIPHPUnitTestShow404Exception $e)
@@ -203,6 +199,14 @@ class CIPHPUnitTestRequest
 		// 404 checking
 		if (! class_exists($class) || ! method_exists($class, $method))
 		{
+			// If 404, CodeIgniter instance is not created yet. So create it here
+			// Because we need CI->output->_status to store info
+			$CI =& get_instance();
+			if ($CI === null)
+			{
+				new CI_Controller();
+			}
+
 			show_404($class.'::'.$method . '() is not found');
 		}
 
@@ -286,10 +290,10 @@ class CIPHPUnitTestRequest
 
 		// Create controller
 		$controller = new $class;
-		$this->CI =& get_instance();
+		$CI =& get_instance();
 
 		// Set CodeIgniter instance to TestCase
-		$this->testCase->setCI($this->CI);
+		$this->testCase->setCI($CI);
 
 		// Set default response code 200
 		set_status_header(200);
@@ -298,7 +302,7 @@ class CIPHPUnitTestRequest
 		{
 			foreach ($this->callables as $callable)
 			{
-				$callable($this->CI);
+				$callable($CI);
 			}
 		}
 
@@ -310,7 +314,7 @@ class CIPHPUnitTestRequest
 
 		if ($output == '')
 		{
-			$output = $this->CI->output->get_output();
+			$output = $CI->output->get_output();
 		}
 
 		$this->callHook('post_controller');
@@ -326,11 +330,12 @@ class CIPHPUnitTestRequest
 	 */
 	public function getStatus()
 	{
-		if (! isset($this->CI->output->_status))
+		$CI =& get_instance();
+		if (! isset($CI->output->_status))
 		{
 			throw new LogicException('Status code is not set. You must call $this->request() first');
 		}
 
-		return $this->CI->output->_status;
+		return $CI->output->_status;
 	}
 }

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -202,7 +202,7 @@ class CIPHPUnitTestRequest
 			// If 404, CodeIgniter instance is not created yet. So create it here
 			// Because we need CI->output->_status to store info
 			$CI =& get_instance();
-			if ($CI === null)
+			if ($CI instanceof CIPHPUnitTestNullCodeIgniter)
 			{
 				new CI_Controller();
 			}

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRouter.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRouter.php
@@ -55,6 +55,14 @@ class CIPHPUnitTestRouter
 
 		if ($e404)
 		{
+			// If 404, CodeIgniter instance is not created yet. So create it here.
+			// Because we need CI->output->_status
+			$CI =& get_instance();
+			if ($CI === null)
+			{
+				new CI_Controller();
+			}
+
 			show_404($RTR->directory.$class.'/'.$method.' is not found');
 		}
 

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRouter.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRouter.php
@@ -58,7 +58,7 @@ class CIPHPUnitTestRouter
 			// If 404, CodeIgniter instance is not created yet. So create it here.
 			// Because we need CI->output->_status
 			$CI =& get_instance();
-			if ($CI === null)
+			if ($CI instanceof CIPHPUnitTestNullCodeIgniter)
 			{
 				new CI_Controller();
 			}

--- a/application/tests/_ci_phpunit_test/functions.php
+++ b/application/tests/_ci_phpunit_test/functions.php
@@ -63,7 +63,7 @@ function reset_instance()
 	CIPHPUnitTest::loadLoader();
 
 	// Remove CodeIgniter instance
-	$CI = null;
+	$CI = new CIPHPUnitTestNullCodeIgniter();
 }
 
 /**

--- a/application/tests/_ci_phpunit_test/functions.php
+++ b/application/tests/_ci_phpunit_test/functions.php
@@ -61,6 +61,9 @@ function reset_instance()
 	load_class('Lang', 'core');
 	
 	CIPHPUnitTest::loadLoader();
+
+	// Remove CodeIgniter instance
+	$CI = null;
 }
 
 /**

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -4,12 +4,12 @@
 
 ### Fixed
 
-* Fix wrong implementation of resetting CodeIgniter instance. Now `reset_instance()` sets `null` to *CodeIgniter instance*. See [#74](https://github.com/kenjis/ci-phpunit-test/pull/74).
+* Fix wrong implementation of resetting CodeIgniter instance. Now `reset_instance()` remove the existing *CodeIgniter instance*. See [#74](https://github.com/kenjis/ci-phpunit-test/pull/74).
 
 ### Changed
 
 * Now `$this->getDouble()` does not call the original constructor by default. See [Function/Class Reference](https://github.com/kenjis/ci-phpunit-test/blob/master/docs/FunctionAndClassReference.md#testcasegetdoubleclassname-params-enable_constructor--false).
-* Now `reset_instance()` sets `null` to *CodeIgniter instance*. See [#74](https://github.com/kenjis/ci-phpunit-test/pull/74).
+* Now `reset_instance()` remove the existing *CodeIgniter instance*. See [#74](https://github.com/kenjis/ci-phpunit-test/pull/74).
 
 ### Added
 

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -8,7 +8,8 @@
 
 ### Changed
 
-* Now `$this->getDouble()` does not call the original constructor. See [#74](https://github.com/kenjis/ci-phpunit-test/pull/74).
+* Now `$this->getDouble()` does not call the original constructor by default. See [Function/Class Reference](https://github.com/kenjis/ci-phpunit-test/blob/master/docs/FunctionAndClassReference.md#testcasegetdoubleclassname-params-enable_constructor--false).
+* Now `reset_instance()` sets `null` to *CodeIgniter instance*. See [#74](https://github.com/kenjis/ci-phpunit-test/pull/74).
 
 ### Added
 

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -2,6 +2,14 @@
 
 ## v0.10.0 (Not Released)
 
+### Fixed
+
+* Fix wrong implementation of resetting CodeIgniter instance. Now `reset_instance()` sets `null` to *CodeIgniter instance*. See [#74](https://github.com/kenjis/ci-phpunit-test/pull/74).
+
+### Changed
+
+* Now `$this->getDouble()` does not call the original constructor. See [#74](https://github.com/kenjis/ci-phpunit-test/pull/74).
+
 ### Added
 
 * NetBeans test suite provider `application/tests/_ci_phpunit_test/TestSuiteProvider.php`. To use it, go to *Project Properties* > *Testing*, check *Use Custom Test Suite* checkbox, and select the file.

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -1,6 +1,6 @@
 # CI PHPUnit Test for CodeIgniter 3.0
 
-version: **v0.10.0** | 
+version: **v0.10.0 (Not Released)** | 
 [v0.9.1](https://github.com/kenjis/ci-phpunit-test/blob/v0.9.1/docs/FunctionAndClassReference.md) | 
 [v0.8.2](https://github.com/kenjis/ci-phpunit-test/blob/v0.8.2/docs/FunctionAndClassReference.md) | 
 [v0.7.0](https://github.com/kenjis/ci-phpunit-test/blob/v0.7.0/docs/FunctionAndClassReference.md) | 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -60,7 +60,7 @@ $this->CI =& get_instance();
 
 Normally, you don't have to use this function. Use [`TestCase::resetInstance()`](#testcaseresetinstance) method instead.
 
-**Note:** Before you create a new controller instance, `get_instance()` returns `null`.
+**Note:** Before you create a new controller instance, `get_instance()` returns `CIPHPUnitTestNullCodeIgniter` object.
 
 ### *function* `set_is_cli($return)`
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -27,7 +27,7 @@ version: **v0.10.0** |
 	- [`TestCase::assertResponseCode($code)`](#testcaseassertresponsecodecode)
 	- [`TestCase::assertRedirect($uri, $code = null)`](#testcaseassertredirecturi-code--null)
 	- [`TestCase::assertResponseHeader($name, $value)`](#testcaseassertresponseheadername-value)
-	- [`TestCase::getDouble($classname, $params)`](#testcasegetdoubleclassname-params)
+	- [`TestCase::getDouble($classname, $params, $enable_constructor)`](#testcasegetdoubleclassname-params-enable_constructor)
 	- [`TestCase::verifyInvoked($mock, $method, $params)`](#testcaseverifyinvokedmock-method-params)
 	- [`TestCase::verifyInvokedOnce($mock, $method, $params)`](#testcaseverifyinvokedoncemock-method-params)
 	- [`TestCase::verifyInvokedMultipleTimes($mock, $method, $times, $params)`](#testcaseverifyinvokedmultipletimesmock-method-times-params)
@@ -286,12 +286,13 @@ $this->assertResponseHeader(
 
 **Note:** This method can only assert headers set by `$this->output->set_header()` method.
 
-#### `TestCase::getDouble($classname, $params)`
+#### `TestCase::getDouble($classname, $params, $enable_constructor)`
 
-| param      | type    | description                   |
-|------------|---------|-------------------------------|
-|`$classname`| string  | class name                    |
-|`$params`   | array   | [method_name => return_value] |
+| param               | type    | description                   |
+|---------------------|---------|-------------------------------|
+|`$classname`         | string  | class name                    |
+|`$params`            | array   | [method_name => return_value] |
+|`$enable_constructor`| bool    | enable constructor or not     |
 
 `returns` (object) PHPUnit mock object
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -27,7 +27,7 @@ version: **v0.10.0** |
 	- [`TestCase::assertResponseCode($code)`](#testcaseassertresponsecodecode)
 	- [`TestCase::assertRedirect($uri, $code = null)`](#testcaseassertredirecturi-code--null)
 	- [`TestCase::assertResponseHeader($name, $value)`](#testcaseassertresponseheadername-value)
-	- [`TestCase::getDouble($classname, $params, $enable_constructor)`](#testcasegetdoubleclassname-params-enable_constructor)
+	- [`TestCase::getDouble($classname, $params, $enable_constructor = false)`](#testcasegetdoubleclassname-params-enable_constructor--false)
 	- [`TestCase::verifyInvoked($mock, $method, $params)`](#testcaseverifyinvokedmock-method-params)
 	- [`TestCase::verifyInvokedOnce($mock, $method, $params)`](#testcaseverifyinvokedoncemock-method-params)
 	- [`TestCase::verifyInvokedMultipleTimes($mock, $method, $times, $params)`](#testcaseverifyinvokedmultipletimesmock-method-times-params)
@@ -286,7 +286,7 @@ $this->assertResponseHeader(
 
 **Note:** This method can only assert headers set by `$this->output->set_header()` method.
 
-#### `TestCase::getDouble($classname, $params, $enable_constructor)`
+#### `TestCase::getDouble($classname, $params, $enable_constructor = false)`
 
 | param               | type    | description                   |
 |---------------------|---------|-------------------------------|

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -1,6 +1,7 @@
 # CI PHPUnit Test for CodeIgniter 3.0
 
-version: **v0.9.1** | 
+version: **v0.10.0** | 
+[v0.9.1](https://github.com/kenjis/ci-phpunit-test/blob/v0.9.1/docs/FunctionAndClassReference.md) | 
 [v0.8.2](https://github.com/kenjis/ci-phpunit-test/blob/v0.8.2/docs/FunctionAndClassReference.md) | 
 [v0.7.0](https://github.com/kenjis/ci-phpunit-test/blob/v0.7.0/docs/FunctionAndClassReference.md) | 
 [v0.6.2](https://github.com/kenjis/ci-phpunit-test/blob/v0.6.2/docs/FunctionAndClassReference.md) | 
@@ -59,7 +60,7 @@ $this->CI =& get_instance();
 
 Normally, you don't have to use this function. Use [`TestCase::resetInstance()`](#testcaseresetinstance) method instead.
 
-**Note:** To be accurate, `reset_instance()` only resets the status of `load_class()` and `is_loaded()`. So before you create a new controller, the current CodeIgniter instance does not change. For example, if you call `$this->load->library()`, before you create a new controller, it may cause `Unable to locate the specified class` error.
+**Note:** Before you create a new controller instance, `get_instance()` returns `null`.
 
 ### *function* `set_is_cli($return)`
 
@@ -298,6 +299,7 @@ Gets PHPUnit mock object.
 
 ~~~php
 $email = $this->getMockBuilder('CI_Email')
+	->disableOriginalConstructor()
 	->setMethods(['send'])
 	->getMock();
 $email->method('send')

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -313,6 +313,22 @@ You could write code above like below:
 $email = $this->getDouble('CI_Email', ['send' => TRUE]);
 ~~~
 
+**Upgrade Note for v0.10.0**
+
+v0.10.0 has changed the default behavior of `$this->getDouble()` and disabled original constructor. If the change causes errors, update your test code like below:
+
+*before:*
+~~~php
+$validation = $this->getDouble('CI_Form_validation', ['run' => TRUE]);
+~~~
+
+↓
+
+*after:*
+~~~php
+$validation = $this->getDouble('CI_Form_validation', ['run' => TRUE], TRUE);
+~~~
+
 #### `TestCase::verifyInvoked($mock, $method, $params)`
 
 | param   | type   | description         |

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -1,6 +1,6 @@
 # CI PHPUnit Test for CodeIgniter 3.0
 
-version: **v0.10.0** | 
+version: **v0.10.0 (Not Released)** | 
 [v0.9.1](https://github.com/kenjis/ci-phpunit-test/blob/v0.9.1/docs/HowToWriteTests.md) | 
 [v0.8.2](https://github.com/kenjis/ci-phpunit-test/blob/v0.8.2/docs/HowToWriteTests.md) | 
 [v0.7.0](https://github.com/kenjis/ci-phpunit-test/blob/v0.7.0/docs/HowToWriteTests.md) | 

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -1,6 +1,7 @@
 # CI PHPUnit Test for CodeIgniter 3.0
 
-version: **v0.9.1** | 
+version: **v0.10.0** | 
+[v0.9.1](https://github.com/kenjis/ci-phpunit-test/blob/v0.9.1/docs/HowToWriteTests.md) | 
 [v0.8.2](https://github.com/kenjis/ci-phpunit-test/blob/v0.8.2/docs/HowToWriteTests.md) | 
 [v0.7.0](https://github.com/kenjis/ci-phpunit-test/blob/v0.7.0/docs/HowToWriteTests.md) | 
 [v0.6.2](https://github.com/kenjis/ci-phpunit-test/blob/v0.6.2/docs/HowToWriteTests.md) | 
@@ -486,7 +487,7 @@ class Auth extends CI_Controller
 
 In this case, You can use [$this->request->setCallablePreConstructor()](FunctionAndClassReference.md#request-setcallablepreconstructor) method and [load_class_instance()](FunctionAndClassReference.md#function-load_class_instanceclassname-instance) function in *CI PHPUnit Test*.
 
-**Note:** Unlike `$this->request->setCallable()`, this callback runs before the controller is created. So there is no CodeIgniter instance which you use at your testing yet. You can't use CodeIgniter functions basically.
+**Note:** Unlike `$this->request->setCallable()`, this callback runs before the controller is created. So there is no CodeIgniter instance yet. You can't use CodeIgniter objects.
 
 ~~~php
 	public function test_index_logged_in()
@@ -506,8 +507,6 @@ In this case, You can use [$this->request->setCallablePreConstructor()](Function
 		$this->assertContains('You are logged in.', $output);
 	}
 ~~~
-
-**Note:** Don't call CodeIgniter's loading methods like `$this->load->model()`, `$this->load->library()` or so in the callbacks. It may cause `Unable to locate the specified class` error. If you have to call CodeIgniter's loading methods in the callbacks, please try to load with CodeIgniter loader before you create a mock object. It might be a workaround.
 
 See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/v0.9.0/application/tests/controllers/Auth_check_in_construct_test.php).
 


### PR DESCRIPTION
### [BC break]

**Note:** I change the content here. You can see the *Original Content* at the bottom.

This is BC break, but fixes wrong implementation of resetting CodeIgniter instance.

* `reset_instance()` removes the existing *CodeIgniter instance*.
* `$this->getDouble()` does not call the original constructor by default.

The current implementation (v0.9.1 and before), `reset_instance()` does not remove the current *CodeIgniter instance*. When you create a new controller, the *CodeIgniter instance* just will become new one.

It means if you use the CodeIgniter objects in *CodeIgniter instance* (eg, `$this->...` or `$CI =& get_instance(); $CI->...`) after calling `reset_instance()` or in the `$this->request->setCallablePreConstructor()`, you use the previous *CodeIgniter instance* and its objects inside.

This is not correct implementation. Because before creating a controller, there should be no *CodeIgniter instance*.

This PR remove the previous *CodeIgniter instance* or set null object to `get_instance()` in the `reset_instance()`.

If you call CodeIgniter methods like `$this->...` in `$this->request->setCallablePreConstructor()`, the test code will cause error.

### Original Content

This PR fixes the error:

> Unable to locate the specified class: Foo.php

And may solve the limitation that is [documented](https://github.com/kenjis/ci-phpunit-test/blob/master/docs/HowToWriteTests.md#request-and-use-mocks):

> Note: When you have never loaded a class with CodeIgniter loader, if you make mock object for the class, your application code may not work correclty. If you have got error, please try to load it before getting mock object.

If anybody has any troubles with your exsiting test cases when you apply this patch, please let me know.
