### PR TITLE
Fix "Class not found error" with renamed libs from autoload config

### DIFF
--- a/application/tests/_ci_phpunit_test/replacing/core/Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/Loader.php
@@ -1019,8 +1019,8 @@ class CI_Loader {
 			$filepath = $path.'libraries/'.$subdir.$class.'.php';
 
 			// Safety: Was the class already loaded by a previous call?
-//			if (class_exists($class, FALSE))
-//			{
+			if (class_exists($class, FALSE))
+			{
 				// Before we deem this to be a duplicate request, let's see
 				// if a custom object name is being supplied. If so, we'll
 				// return a new instance of the object
@@ -1035,7 +1035,7 @@ class CI_Loader {
 
 //				log_message('debug', $class.' class already loaded. Second attempt ignored.');
 //				return;
-//			}
+			}
 			// Does the file exist? No? Bummer...
 			if ( ! file_exists($filepath))
 			{


### PR DESCRIPTION
If you have an autoload.php with a line like this:
```
$autoload['libraries'] = array('Doctrine' => 'dt');
```
Then you will end up with a `Fatal error: Class 'Doctrine' not found` even tough the code works fine when not under test.
This seems to be because the removed `class_exists($class)` check