### PR TITLE
Add support for CI_Output::_display and display_override

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -323,6 +323,11 @@ class CIPHPUnitTestRequest
 
 		// Call controller method
 		call_user_func_array([$controller, $method], $params);
+		if ($this->callHook('display_override') !== true)
+		{
+			$CI->output->_display();
+		}
+
 		$output = ob_get_clean();
 
 		if ($output == '')

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kenjis/ci-phpunit-test",
+    "name": "complex857/ci-phpunit-test",
     "description": "An easier way to use PHPUnit with CodeIgniter 3.0",
     "keywords": [
         "phpunit",


### PR DESCRIPTION
By default CI will call `CI_Output::_display()` after the controller method
returned (unless you have display_override hook(s)).
The `CIPHPUnitTestRequest` class should do the same, so code that relies on this
method beeing called (it will call `$CI->_output()` if it's callable)
to generate output will work the same under test.

See:
http://www.codeigniter.com/user_guide/libraries/output.html?highlight=_output#CI_Output::_display
https://github.com/bcit-ci/CodeIgniter/blob/0abc55a22535586929fb146a81d1cee68dbccd10/system/core/CodeIgniter.php#L531-L534