### PR TITLE
assertRedirect does not work with external redirects

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -335,7 +335,12 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 			$CI =& get_instance();
 			$CI->load->helper('url');
 		}
-		$absolute_url = site_url($uri);
+
+		if (! preg_match('#^(\w+:)?//#i', $uri))
+		{
+			$uri = site_url($uri);
+		}
+		$absolute_url = $uri;
 		$expected = 'Redirect to ' . $absolute_url;
 
 		$this->assertSame(


### PR DESCRIPTION
A controller with `redirect('http://www.example.com')` fails `assertRedirect('http://www.example.com')`, it's expecting something along the lines of `http://localhost:8000/http://www.example.com`.  I copied the regex from the replacement url_helper.php.