### PR TITLE
phpunitコマンドにディレクトリを引数に与えると正常に動かない問題の修正

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -29,6 +29,8 @@ class CIPHPUnitTest
 		$_SERVER['argc'] = 2;
 
 		self::$autoload_dirs = $autoload_dirs;
+		
+		$cwd_backup = getcwd();
 
 		// Load autoloader for ci-phpunit-test
 		require __DIR__ . '/autoloader.php';
@@ -84,6 +86,9 @@ class CIPHPUnitTest
 
 		// Restore $_SERVER. We need this for NetBeans
 		$_SERVER = $_server_backup;
+		
+		// Restore cwd to use `Usage: phpunit [options] <directory>`
+		chdir($cwd_backup);
 	}
 
 	public static function createCodeIgniterInstance()

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -52,6 +52,9 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 			'index.php',
 		];
 		$_SERVER['argc'] = 1;
+		
+		// Reset current directroy
+		chdir(FCPATH);
 	}
 
 	/**


### PR DESCRIPTION
Bootstrap.phpの実行の前後でカレントディレクトリが変わっていたため `Usage: phpunit <directory>` が正常に動かなくなっていました

修正点
・Bootstrap.phpの実行後、カレントディレクトリを元に戻すように修正しました
・テスト実行時のカレントディレクトリはCIのルートにするため、 `CIPHPUnitTestCase::setUpBeforeClass` にカレントディレクトリのリセット処理を追加しました

開発に利用する上で不便を感じる点なので修正をしました。