### PR TITLE
`Usage: phpunit <directory>` doesn't work.

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -29,6 +29,8 @@ class CIPHPUnitTest
 		$_SERVER['argc'] = 2;
 
 		self::$autoload_dirs = $autoload_dirs;
+		
+		$cwd_backup = getcwd();
 
 		// Load autoloader for ci-phpunit-test
 		require __DIR__ . '/autoloader.php';
@@ -84,6 +86,9 @@ class CIPHPUnitTest
 
 		// Restore $_SERVER. We need this for NetBeans
 		$_SERVER = $_server_backup;
+		
+		// Restore cwd to use `Usage: phpunit [options] <directory>`
+		chdir($cwd_backup);
 	}
 
 	public static function createCodeIgniterInstance()

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -52,6 +52,9 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 			'index.php',
 		];
 		$_SERVER['argc'] = 1;
+		
+		// Reset current directroy
+		chdir(FCPATH);
 	}
 
 	/**


### PR DESCRIPTION
Current directory has changed after loading Bootstrap.php.

Updates
- Add restoring cwd after running Bootstrap.php
- Add reseting cwd code at `CIPHPUnitTestCase::setUpBeforeClass` to use CI root cwd while testing

Retake #108 in English