### PR TITLE
openssl_random_pseudo_bytes Warning fix

### DIFF
--- a/application/tests/_ci_phpunit_test/patcher/Patcher/FunctionPatcher/Proxy.php
+++ b/application/tests/_ci_phpunit_test/patcher/Patcher/FunctionPatcher/Proxy.php
@@ -250,7 +250,7 @@ class Proxy
 	}
 
 	public static function openssl_random_pseudo_bytes(
-		$length, &$crypto_strong
+		$length, &$crypto_strong = null
 	)
 	{
 		$function = 'openssl_random_pseudo_bytes';


### PR DESCRIPTION
The following error occurred when the second argument of " openssl_random_pseudo_bytes " does not exist .

Missing argument 2

Therefore , I set the default value of " null " in the second argument .