### PR TITLE
change getDouble add constructor args

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -33,7 +33,7 @@ class CIPHPUnitTestDouble
 	 * @param  string $classname
 	 * @param  array  $params             [method_name => return_value]
 	 * @param  mixed  $constructor_args enable constructor and args or not
-	 * @
+	 * 
 	 * @return object PHPUnit mock object
 	 */
 	public function getDouble($classname, $params, $constructor_args = [])

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -32,7 +32,7 @@ class CIPHPUnitTestDouble
 	 *
 	 * @param  string $classname
 	 * @param  array  $params             [method_name => return_value]
-	 * @param  bool   $enable_constructor enable constructor or not
+	 * @param  mixed   $enable_constructor enable constructor and args or not
 	 * @return object PHPUnit mock object
 	 */
 	public function getDouble($classname, $params, $enable_constructor = false)
@@ -47,6 +47,10 @@ class CIPHPUnitTestDouble
 		if (! $enable_constructor)
 		{
 			$mock->disableOriginalConstructor();
+		}
+		elseif (is_array($enable_constructor))
+		{
+			$mock->setConstructorArgs($enable_constructor);
 		}
 		$mock = $mock->setMethods($methods)->getMock();
 

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -36,7 +36,7 @@ class CIPHPUnitTestDouble
 	 * 
 	 * @return object PHPUnit mock object
 	 */
-	public function getDouble($classname, $params, $constructor_args = [])
+	public function getDouble($classname, $params, $constructor_args = false)
 	{
 		$methods = array_keys($params);
 
@@ -45,7 +45,7 @@ class CIPHPUnitTestDouble
 		// methods in it. But we can't use them in
 		// `$this->request->setCallablePreConstructor()`
 		$mock = $this->testCase->getMockBuilder($classname);
-		if (! $constructor_args)
+		if ($constructor_args === false)
 		{
 			$mock->disableOriginalConstructor();
 		}

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -32,10 +32,11 @@ class CIPHPUnitTestDouble
 	 *
 	 * @param  string $classname
 	 * @param  array  $params             [method_name => return_value]
-	 * @param  mixed   $enable_constructor enable constructor and args or not
+	 * @param  mixed  $constructor_args enable constructor and args or not
+	 * @
 	 * @return object PHPUnit mock object
 	 */
-	public function getDouble($classname, $params, $enable_constructor = false)
+	public function getDouble($classname, $params, $constructor_args = [])
 	{
 		$methods = array_keys($params);
 
@@ -44,13 +45,13 @@ class CIPHPUnitTestDouble
 		// methods in it. But we can't use them in
 		// `$this->request->setCallablePreConstructor()`
 		$mock = $this->testCase->getMockBuilder($classname);
-		if (! $enable_constructor)
+		if (! $constructor_args)
 		{
 			$mock->disableOriginalConstructor();
 		}
-		elseif (is_array($enable_constructor))
+		elseif (is_array($constructor_args))
 		{
-			$mock->setConstructorArgs($enable_constructor);
+			$mock->setConstructorArgs($constructor_args);
 		}
 		$mock = $mock->setMethods($methods)->getMock();
 


### PR DESCRIPTION
If i want to create a " Mock " on "SplFileObject" this feature was thought that want .

``` php
<?php

public function test_parse_csv()
{
    // disable constructor
    $spl_mock = $this->getDobule('SplFileObject', [
         'current' => ['foo', 'bar'],
         'next'      => NULL
    ]);
}
```

_LogicException: The parent constructor was not called: the object is in an invalid state_
# 

``` php
<?php

public function test_parse_csv()
{
    // enable constructor
    $spl_mock = $this->getDobule('SplFileObject', [
         'current' => ['foo', 'bar'],
         'next'      => NULL
    ], true);
}
```

_RuntimeException: SplFileObject::__construct() expects at least 1 parameter, 0 given_
# 

Therefore , I want to describe as follows .

``` php
<?php

public function test_parse_csv()
{
    // set constructor args
    $spl_mock = $this->getDobule(
        'SplFileObject',
        [
            'current' => ['foo', 'bar'],
            'next'    => NULL
        ],
        ['php://memory']
    );
}
```
