### PR TITLE
add @ before call_user_func_array()

### DIFF
--- a/application/tests/_ci_phpunit_test/patcher/Patcher/FunctionPatcher/Proxy.php
+++ b/application/tests/_ci_phpunit_test/patcher/Patcher/FunctionPatcher/Proxy.php
@@ -181,7 +181,7 @@ class Proxy
 			'invoke_func: ' . $function . '() not patched (no patch)'
 		);
 		self::checkPassedByReference($function);
-		return call_user_func_array($function, $arguments);
+		return @call_user_func_array($function, $arguments);
 	}
 
 	protected static function checkPassedByReference($function)


### PR DESCRIPTION
using codeigniter-restserver, `echo`/`print_r()` cause warning.
but echo/print_r() is useful. so I should add `@` before call_user_func_array().

```
Severity:    Warning
Message:     Cannot modify header information - headers already sent by (output started at /vagrant/vendor/phpunit/phpunit/src/Util/Printer.php:134)
Filename:    /vagrant/application/tests/_ci_phpunit_test/patcher/Patcher/FunctionPatcher/Proxy.php
Line Number: 184
```
