### PR TITLE
fix config/router.php setting closure error

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -16,6 +16,7 @@
 class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 {
 	protected $_error_reporting = -1;
+	protected $backupGlobalsBlacklist = ['RTR'];
 	
 	/**
 	 * @var CI_Controller CodeIgniter instance


### PR DESCRIPTION
If set the "Closure" to "config/router.php" the following error occurred.

```shell
Exception: Serialization of 'Closure' is not allowed
```

An error has set the "RTR" to "backupGlobalsBlacklist" so as not to generate
PHPUnit backupGrobals ignore Router Class