### PR TITLE
Use nikic/php-parser as a Composer dependency if you use Composer

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -35,15 +35,6 @@ class CIPHPUnitTest
 		// Load autoloader for ci-phpunit-test
 		require __DIR__ . '/autoloader.php';
 
-		// Autoloader for PHP-Parser
-		// Don't use `require`, because we may have required already
-		// in `patcher/bootstrap.php`
-		if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-			require_once __DIR__ . '/patcher/third_party/PHP-Parser-3.0.3/lib/bootstrap.php';
-		} else {
-			require_once __DIR__ . '/patcher/third_party/PHP-Parser-2.1.1/lib/bootstrap.php';
-		}
-
 		require APPPATH . '/tests/TestCase.php';
 
 		$db_test_case_file = APPPATH . '/tests/DbTestCase.php';

--- a/application/tests/_ci_phpunit_test/patcher/bootstrap.php
+++ b/application/tests/_ci_phpunit_test/patcher/bootstrap.php
@@ -8,20 +8,27 @@
  * @link       https://github.com/kenjis/ci-phpunit-test
  */
 
-if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
-	// Autoloader for PHP-Parser
-	// Don't use `require`, because we must require it in CIPHPUnitTest::init()
-	// for providing autoloading when we don't use Monkey Patching
-	require_once __DIR__ . '/third_party/PHP-Parser-3.0.3/lib/bootstrap.php';
-
-	require __DIR__ . '/3.x/MonkeyPatchManager.php';
-} else {
-	// Autoloader for PHP-Parser
-	// Don't use `require`, because we must require it in CIPHPUnitTest::init()
-	// for providing autoloading when we don't use Monkey Patching
-	require_once __DIR__ . '/third_party/PHP-Parser-2.1.1/lib/bootstrap.php';
-
-	require __DIR__ . '/2.x/MonkeyPatchManager.php';
+// If you use Composer
+if (class_exists('PhpParser\Autoloader')) {
+	if (method_exists('PhpParser\Node\Name','set')) {
+		// PHP-Parser 2.x
+		require __DIR__ . '/2.x/MonkeyPatchManager.php';
+	} else {
+		// PHP-Parser 3.x
+		require __DIR__ . '/3.x/MonkeyPatchManager.php';
+	}
+}
+// If you don't use Composer
+else {
+	if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
+		// Use PHP-Parser 3.x
+		require __DIR__ . '/third_party/PHP-Parser-3.0.3/lib/bootstrap.php';
+		require __DIR__ . '/3.x/MonkeyPatchManager.php';
+	} else {
+		// Use PHP-Parser 2.x
+		require __DIR__ . '/third_party/PHP-Parser-2.1.1/lib/bootstrap.php';
+		require __DIR__ . '/2.x/MonkeyPatchManager.php';
+	}
 }
 
 require __DIR__ . '/IncludeStream.php';

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,8 @@
         "forum": "http://forum.codeigniter.com/thread-61725.html"
     },
     "require": {
-        "php": ">=5.4.0"
-    },
-    "replace": {
-        "nikic/php-parser": "3.0.2",
-        "nikic/php-parser": "2.1.1"
+        "php": ">=5.4.0",
+        "nikic/php-parser": "^2.1|^3.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
PHP-Parser  is only used if you use *Monkey Patching* in ci-phpunit-test.

Before:
* ci-phpnit-test has PHP-Parser source code inside, and always uses it.
* In Composer context, ci-phpunit-test replaces PHP-Parser.

After:
* If you use Composer (you install ci-phpunit-test via Composer), ci-phpunit-test uses PHP-Parser  Composer package.
* In Composer context, ci-phpunit-test depends on PHP-Parser package.
* If you don't use Composer, ci-phpunit-test uses PHP-Parser source code inside.
