### PR TITLE
Fix to be able to set phpunit-mock-objects stub to the return value of method

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -57,7 +57,10 @@ class CIPHPUnitTestDouble
 
 		foreach ($params as $method => $return)
 		{
-			if (is_object($return) && $return instanceof Closure) {
+			if (is_object($return) && $return instanceof PHPUnit_Framework_MockObject_Stub) {
+				$mock->expects($this->testCase->any())->method($method)
+					->will($return);
+			} elseif (is_object($return) && $return instanceof Closure) {
 				$mock->expects($this->testCase->any())->method($method)
 					->willReturnCallback($return);
 			} else {

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -459,6 +459,17 @@ $ret = function () {
 $mock = $this->getDouble('CI_Email', ['send' => $ret]);
 ~~~
 
+You can set an object that implements `PHPUnit_Framework_MockObject_Stub` as the return value of the mocked method.
+
+~~~php
+$mock = $this->getDouble('CI_Email', [
+    'to'      => $this->returnSelf(),
+    'subject' => $this->returnSelf(),
+    'send'    => TRUE,
+]);
+~~~
+
+
 **Upgrade Note for v0.10.0**
 
 v0.10.0 has changed the default behavior of `$this->getDouble()` and disabled original constructor. If the change causes errors, update your test code like below:


### PR DESCRIPTION
I think that this pull request is effective when a chain method is described.

For example, in the case of the following processing

```php
<?php
class Shop_model extends CI_Model {
...
     public function send_buy_mail()
     {
             return $this->email->to('foo@example.com', 'test')
                      ->subject('Thanks !')
                      ->message('Thank you very match!!')
                      ->send();
     }
}
```

It can be implemented as follows.

```php
<?php
class Shop_model_test extends TestCase {
...
     public function test_send()
     {
             $this->shop_model->email = $this->getDouble('CI_Email', [
                   'to'      => $this->returnSelf(), //PHPUnit_Framework_MockObject_Stub_ReturnSelf
                   'subject' => $this->returnSelf(),
                   'message' => $this->returnSelf(),
                   'send'    => TRUE
             ]);
     }
}
```