### PR TITLE
Loader::_ci_prepare_view_vars(): undefined variable

### DIFF
--- a/application/tests/_ci_phpunit_test/replacing/core/Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/Loader.php
@@ -1448,7 +1448,7 @@ class CI_Loader {
 		if ( ! is_array($vars))
 		{
 			$vars = is_object($vars)
-				? get_object_vars($object)
+				? get_object_vars($vars)
 				: array();
 		}
 


### PR DESCRIPTION
$object is undefined; changed it to $vars (the only defined variable up to that point).