### PR TITLE
Don't overwrite the response set in __construct()

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -331,8 +331,11 @@ class CIPHPUnitTestRequest
 		// Set CodeIgniter instance to TestCase
 		$this->testCase->setCI($CI);
 
-		// Set default response code 200
-		set_status_header(200);
+		if (!isset($CI->output->_status)) {  // prevent overwriting, if already set in the $class::__construct()
+			// Set default response code 200
+			set_status_header(200);
+		}
+		
 		// Run callable
 		if ($this->callables !== [])
 		{


### PR DESCRIPTION
It would be set to `200`, no matter what.
If a satus was set in the constructor, it would get replaced with `200`.

Fixes #194