### PR TITLE
Adding a check to just see if a cookie is present or not

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -382,6 +382,13 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 			return;
 		}
 
+		// We only want to check for cookie set, not the actual value
+		if ($value === null) 
+		{
+			$this->assertTrue(true);
+			return;
+		}
+
 		foreach ($value as $key => $val)
 		{
 			$this->assertEquals(


### PR DESCRIPTION
In some cases I just need to test that a cookie is set and don't care about the value. Example is a login situation where a random value is assigned to the cookie at login. Passing null as value to assertResponseCookie would simply check that cookie is there.