### PR TITLE
Add function to check to just see if a cookie is present or not

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -35,7 +35,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	 * @var CI_Controller CodeIgniter instance
 	 */
 	protected $CI;
-	
+
 	protected $class_map = [
 		'request'    => 'CIPHPUnitTestRequest',
 		'double'     => 'CIPHPUnitTestDouble',
@@ -66,7 +66,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 			'index.php',
 		];
 		$_SERVER['argc'] = 1;
-		
+
 		// Reset current directroy
 		chdir(FCPATH);
 	}
@@ -302,7 +302,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Asserts HTTP response code
-	 * 
+	 *
 	 * @param int $code
 	 */
 	public function assertResponseCode($code)
@@ -319,7 +319,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Asserts HTTP response header
-	 * 
+	 *
 	 * @param string $name  header name
 	 * @param string $value header value
 	 */
@@ -342,7 +342,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Asserts HTTP response cookie
-	 * 
+	 *
 	 * @param string       $name            cookie name
 	 * @param string|array $value           cookie value|array of cookie params
 	 * @param bool         $allow_duplicate whether to allow duplicated cookies
@@ -404,7 +404,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Asserts Redirect
-	 * 
+	 *
 	 * @param string $uri  URI to redirect
 	 * @param int    $code response code
 	 */

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -382,6 +382,16 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 			return;
 		}
 
+		// In case of $this->anything()
+		if (
+			$value instanceof PHPUnit_Framework_Constraint_IsAnything
+			|| $value instanceof PHPUnit\Framework\Constraint\IsAnything
+		)
+		{
+			$this->assertTrue(true);
+			return;
+		}
+
 		foreach ($value as $key => $val)
 		{
 			$this->assertEquals(

--- a/application/tests/_ci_phpunit_test/ChangeLog.md
+++ b/application/tests/_ci_phpunit_test/ChangeLog.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Now you can pass more than 5 arguments to `$this->verifyInvoked*()`. See [#192](https://github.com/kenjis/ci-phpunit-test/pull/192).
+* Now you can assert whether a response cookie is just present or not. See [#205](https://github.com/kenjis/ci-phpunit-test/pull/205).
 
 ### Fixed
 


### PR DESCRIPTION
This PR enables you can write a test like the following:

```php
	public function test_cookie_is_just_set()
	{
		$output = $this->request('GET', 'set_cookie/name_and_value');
		$this->assertResponseCookie(
			'The-Cookie-Name', $this->anything()
		);
	}
```
