### PR TITLE
fix resetInstance disconnect db bug

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
@@ -31,9 +31,15 @@ class CIPHPUnitTestDbTestCase extends CIPHPUnitTestCase
 	 */
 	protected $insertCache = [];
 
+	public function resetInstance()
+	{
+		parent::resetInstance();
+		$this->loadDependencies();
+	}
+
 	protected function loadDependencies()
 	{
-		if ($this->db === null)
+		if ($this->db === null || $this->db->conn_id === false)
 		{
 			$CI =& get_instance();
 			$CI->load->database();


### PR DESCRIPTION
An error occurred when I ran the following code.

```php
<?php
class Sample_model_test extends DbTestCase
{
   private $obj;

    public function setUp()
    {
        parent::setUp();
        $this->obj = $this->newModel('sample_model');
    }

    public function test_sample_insert()
    {
        $this->obj->add_sample('john');
        $this->grabFromDatabase('sample', ['name' => 'john']);
    }
}
```

following error message.

```shell
Error: Call to a member function real_escape_string() on boolean

/vagrant/vendor/codeigniter/framework/system/database/drivers/mysqli/mysqli_driver.php:391
/vagrant/vendor/codeigniter/framework/system/database/DB_driver.php:1143
/vagrant/vendor/codeigniter/framework/system/database/DB_driver.php:1108
/vagrant/vendor/codeigniter/framework/system/database/DB_query_builder.php:683
/vagrant/vendor/codeigniter/framework/system/database/DB_query_builder.php:623
/vagrant/vendor/kenjis/ci-phpunit-test/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php:109
```

This is to close the DB that the CI Instance has when calling `resetInstance`.