### PR TITLE
Fix $this->request can't be called more than once

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -56,6 +56,11 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 		$this->CI = $CI;
 	}
 
+	public function getStrictRequestErrorCheck()
+	{
+		return $this->strictRequestErrorCheck;
+	}
+
 	public function __get($name)
 	{
 		if (isset($this->class_map[$name]))
@@ -136,10 +141,6 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 	 */
 	public function request($http_method, $argv, $params = [])
 	{
-		if ($this->strictRequestErrorCheck) {
-			$this->enableStrictErrorCheck();
-		}
-
 		return $this->request->request($http_method, $argv, $params);
 	}
 

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -10,6 +10,9 @@
 
 class CIPHPUnitTestRequest
 {
+    /**
+     * @var TestCase
+     */
 	protected $testCase;
 
 	/**
@@ -39,7 +42,7 @@ class CIPHPUnitTestRequest
 	 */
 	protected $hooks;
 
-	public function __construct(PHPUnit_Framework_TestCase $testCase)
+	public function __construct(TestCase $testCase)
 	{
 		$this->testCase = $testCase;
 		$this->superGlobal = new CIPHPUnitTestSuperGlobal();

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -128,6 +128,10 @@ class CIPHPUnitTestRequest
 	 */
 	public function request($http_method, $argv, $params = [])
 	{
+		if ($this->testCase->getStrictRequestErrorCheck()) {
+			$this->testCase->enableStrictErrorCheck();
+		}
+
 		if (is_string($argv))
 		{
 			$argv = ltrim($argv, '/');
@@ -142,18 +146,23 @@ class CIPHPUnitTestRequest
 		try {
 			if (is_array($argv))
 			{
-				return $this->callControllerMethod(
+				$ret = $this->callControllerMethod(
 					$http_method, $argv, $params
 				);
+				$this->testCase->disableStrictErrorCheck();
+				return $ret;
 			}
 			else
 			{
-				return $this->requestUri($http_method, $argv, $params);
+				$ret = $this->requestUri($http_method, $argv, $params);
+				$this->testCase->disableStrictErrorCheck();
+				return $ret;
 			}
 		}
 		// redirect()
 		catch (CIPHPUnitTestRedirectException $e)
 		{
+			$this->testCase->disableStrictErrorCheck();
 			if ($e->getCode() === 0)
 			{
 				set_status_header(200);
@@ -168,18 +177,21 @@ class CIPHPUnitTestRequest
 		// show_404()
 		catch (CIPHPUnitTestShow404Exception $e)
 		{
+			$this->testCase->disableStrictErrorCheck();
 			$this->processError($e);
 			return $e->getMessage();
 		}
 		// show_error()
 		catch (CIPHPUnitTestShowErrorException $e)
 		{
+			$this->testCase->disableStrictErrorCheck();
 			$this->processError($e);
 			return $e->getMessage();
 		}
 		// exit()
 		catch (CIPHPUnitTestExitException $e)
 		{
+			$this->testCase->disableStrictErrorCheck();
 			$output = ob_get_clean();
 			return $output;
 		}

--- a/application/tests/_ci_phpunit_test/ChangeLog.md
+++ b/application/tests/_ci_phpunit_test/ChangeLog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Fix bug that installer replaces file path in `tests/Bootstrap.php` with wrong code which causes Parse error. See [#247](https://github.com/kenjis/ci-phpunit-test/pull/247).
+* Fix bug that `$this->request()` can't be called more than once in a test method. See [#248](https://github.com/kenjis/ci-phpunit-test/pull/248).
 
 ### Others
 

--- a/application/tests/_ci_phpunit_test/patcher/2.x/Patcher/FunctionPatcher/Proxy.php
+++ b/application/tests/_ci_phpunit_test/patcher/2.x/Patcher/FunctionPatcher/Proxy.php
@@ -128,7 +128,7 @@ class Proxy
 			}
 			return true;
 		}
-		//Patches the functions only in the class method
+		// Patches the functions only in the class method
 		else
 		{
 			if (self::$patches_to_apply[$function] !== $class_method)


### PR DESCRIPTION
If you call `$this->request()` in one test method, it causes "LogicException Already strict error check mode".

See #245 
