### PR TITLE
Fix patchConstant when the user does not specify $class_method

### DIFF
--- a/application/tests/_ci_phpunit_test/patcher/2.x/Patcher/ConstantPatcher/Proxy.php
+++ b/application/tests/_ci_phpunit_test/patcher/2.x/Patcher/ConstantPatcher/Proxy.php
@@ -29,11 +29,11 @@ class Proxy
 
 	/**
 	 * Set a constant patch
-	 * 
+	 *
 	 * @param string $constant      constant name
 	 * @param mixed  $value         value
 	 * @param string $class_method  class::method to apply this patch
-	 * 
+	 *
 	 * @throws LogicException
 	 */
 	public static function patch($constant, $value, $class_method = null)
@@ -72,7 +72,7 @@ class Proxy
 	{
 		$trace = debug_backtrace();
 		$info = Backtrace::getInfo('ConstantPatcher', $trace);
-		
+
 		$class = strtolower($info['class']);
 		$class_method = strtolower($info['class_method']);
 
@@ -98,7 +98,7 @@ class Proxy
 
 	/**
 	 * Get patched constant value
-	 * 
+	 *
 	 * @param string $constant
 	 * @return mixed
 	 */
@@ -106,7 +106,7 @@ class Proxy
 	{
 		self::logInvocation($constant);
 
-		if (isset(self::$patches_to_apply[$constant]))
+		if (!empty(self::$patches_to_apply[$constant]))
 		{
 			if (! self::checkCalledMethod($constant))
 			{

--- a/application/tests/_ci_phpunit_test/patcher/3.x/Patcher/ConstantPatcher/Proxy.php
+++ b/application/tests/_ci_phpunit_test/patcher/3.x/Patcher/ConstantPatcher/Proxy.php
@@ -29,11 +29,11 @@ class Proxy
 
 	/**
 	 * Set a constant patch
-	 * 
+	 *
 	 * @param string $constant      constant name
 	 * @param mixed  $value         value
 	 * @param string $class_method  class::method to apply this patch
-	 * 
+	 *
 	 * @throws LogicException
 	 */
 	public static function patch($constant, $value, $class_method = null)
@@ -72,7 +72,7 @@ class Proxy
 	{
 		$trace = debug_backtrace();
 		$info = Backtrace::getInfo('ConstantPatcher', $trace);
-		
+
 		$class = strtolower($info['class']);
 		$class_method = strtolower($info['class_method']);
 
@@ -98,7 +98,7 @@ class Proxy
 
 	/**
 	 * Get patched constant value
-	 * 
+	 *
 	 * @param string $constant
 	 * @return mixed
 	 */
@@ -106,7 +106,7 @@ class Proxy
 	{
 		self::logInvocation($constant);
 
-		if (isset(self::$patches_to_apply[$constant]))
+		if (!empty(self::$patches_to_apply[$constant]))
 		{
 			if (! self::checkCalledMethod($constant))
 			{


### PR DESCRIPTION
When a user calls patchConstant without the argument $class_method the docs explain the constant will changed everywhere.

However, the code will store in $patches_to_apply[$constant] the result of strtolower($class_name) ==> strtolower(null) ==> "". When we check if we have to return the patched value we will always return false, as we check with `isset` the variable $patches_to_apply[$constant] (this will always be true) and when we proceed to check the value of $patches_to_apply[$constant] (the empty string) with the current class it always fails the test.

The end result is that a call to patchConstant('FOO', 1); never changes the constant FOO.