### PR TITLE
Corrected error of `typehint`

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -42,7 +42,7 @@ class CIPHPUnitTestRequest
 	 */
 	protected $hooks;
 
-	public function __construct(TestCase $testCase)
+	public function __construct(CIPHPUnitTestCase $testCase)
 	{
 		$this->testCase = $testCase;
 		$this->superGlobal = new CIPHPUnitTestSuperGlobal();


### PR DESCRIPTION
Fixed an issue that occurred an error when referring to `request` property from TestCase.

TestCase inherit `DbTestCase`.