### PR TITLE
Remove parameters that cause warnings in PHPUnit 7 environment

### DIFF
--- a/application/tests/phpunit.xml
+++ b/application/tests/phpunit.xml
@@ -21,6 +21,6 @@
 	<logging>
 		<log type="coverage-html" target="build/coverage"/>
 		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+		<log type="junit" target="build/logs/junit.xml"/>
 	</logging>
 </phpunit>


### PR DESCRIPTION
Hello.

This pull request removes parameters that generate warnings in the PHPUnit 7 environment.

example:
```
$ phpunit
PHPUnit 7.3.2 by Sebastian Bergmann and contributors.
  Warning - The configuration file did not pass validation!
  The following problems have been detected:
  Line 29:
  - Element 'log', attribute 'logIncompleteSkipped': The attribute 'logIncompleteSkipped' is not allowed.
  Test results may not be as expected.
...............................................................  63 / 234 ( 26%)
```

'logIncompleteSkipped' does not work since PHPUnit 6, but it works for PHPUnit 5.