### PR TITLE
CIPHPUnitTest::resetInstance() could creates MY_Controller instead of CI_Controller

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -11,6 +11,7 @@
 class CIPHPUnitTest
 {
 	private static $loader_class = 'CI_Loader';
+	private static $controller_class;
 	private static $autoload_dirs;
 
 	/**
@@ -104,17 +105,52 @@ class CIPHPUnitTest
 		chdir($cwd_backup);
 	}
 
-	public static function createCodeIgniterInstance()
+	/**
+	 * @param bool $use_my_controller
+	 */
+	public static function createCodeIgniterInstance($use_my_controller = false)
 	{
 		if (! self::wiredesignzHmvcInstalled())
 		{
-			new CI_Controller();
+			if ($use_my_controller && self::hasMyController())
+			{
+				new self::$controller_class;
+			}
+			else
+			{
+				new CI_Controller();
+			}
 		}
 		else
 		{
 			new CI();
 			new MX_Controller();
 		}
+	}
+
+	private static function hasMyController()
+	{
+		if (self::$controller_class !== null) {
+			return self::$controller_class !== 'CI_Controller';
+		}
+
+		$my_controller_file =
+			APPPATH . 'core/' . config_item('subclass_prefix') . 'Controller.php';
+
+		if (file_exists($my_controller_file))
+		{
+			$controller_class = config_item('subclass_prefix') . 'Controller';
+			if ( ! class_exists($controller_class))
+			{
+				require $my_controller_file;
+			}
+
+			self::$controller_class = $controller_class;
+			return true;
+		}
+
+		self::$controller_class = 'CI_Controller';
+		return false;
 	}
 
 	public static function wiredesignzHmvcInstalled()

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -92,11 +92,13 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Reset CodeIgniter instance and assign new CodeIgniter instance as $this->CI
+	 *
+	 *  @param bool $use_my_controller
 	 */
-	public function resetInstance()
+	public function resetInstance($use_my_controller = false)
 	{
 		reset_instance();
-		CIPHPUnitTest::createCodeIgniterInstance();
+		CIPHPUnitTest::createCodeIgniterInstance($use_my_controller);
 		$this->CI =& get_instance();
 	}
 

--- a/application/tests/_ci_phpunit_test/ChangeLog.md
+++ b/application/tests/_ci_phpunit_test/ChangeLog.md
@@ -11,7 +11,7 @@
 ### Added
 
 * Now Seeder can call dependent seeders. See [How to Write Tests](https://github.com/kenjis/ci-phpunit-test/blob/master/docs/HowToWriteTests.md#database-seeding).
-
+* `$this->resetInstance()` could create `MY_Controller` instance in stead of `CI_Controller` instance. See [#271](https://github.com/kenjis/ci-phpunit-test/pull/271).
 
 ### Others
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -22,7 +22,7 @@ version: **v0.16.1** |
 - [*function* `set_is_cli($return)`](#function-set_is_clireturn)
 - [*function* `load_class_instance($classname, $instance)`](#function-load_class_instanceclassname-instance)
 - [*class* TestCase](#class-testcase)
-	- [`TestCase::resetInstance()`](#testcaseresetinstanceuse_my_controller--false)
+	- [`TestCase::resetInstance($use_my_controller = false)`](#testcaseresetinstanceuse_my_controller--false)
 	- [`TestCase::request($method, $argv, $params = [])`](#testcaserequestmethod-argv-params--)
 		- [`request->setHeader()`](#request-setheader)
 		- [`request->setFiles($files)`](#request-setfilesfiles)

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -1,6 +1,7 @@
 # ci-phpunit-test for CodeIgniter 3.x
 
-version: **v0.16.1** | 
+version: **v0.17.0** | 
+[v0.16.1](https://github.com/kenjis/ci-phpunit-test/blob/v0.16.1/docs/FunctionAndClassReference.md) | 
 [v0.15.0](https://github.com/kenjis/ci-phpunit-test/blob/v0.15.0/docs/FunctionAndClassReference.md) | 
 [v0.14.0](https://github.com/kenjis/ci-phpunit-test/blob/v0.14.0/docs/FunctionAndClassReference.md) | 
 [v0.13.0](https://github.com/kenjis/ci-phpunit-test/blob/v0.13.0/docs/FunctionAndClassReference.md) | 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -22,7 +22,7 @@ version: **v0.16.1** |
 - [*function* `set_is_cli($return)`](#function-set_is_clireturn)
 - [*function* `load_class_instance($classname, $instance)`](#function-load_class_instanceclassname-instance)
 - [*class* TestCase](#class-testcase)
-	- [`TestCase::resetInstance()`](#testcaseresetinstance)
+	- [`TestCase::resetInstance()`](#testcaseresetinstanceuse_my_controller--false)
 	- [`TestCase::request($method, $argv, $params = [])`](#testcaserequestmethod-argv-params--)
 		- [`request->setHeader()`](#request-setheader)
 		- [`request->setFiles($files)`](#request-setfilesfiles)
@@ -79,7 +79,7 @@ $controller = new Welcome();
 $this->CI =& get_instance();
 ~~~
 
-Normally, you don't have to use this function. Use [`TestCase::resetInstance()`](#testcaseresetinstance) method instead.
+Normally, you don't have to use this function. Use [`TestCase::resetInstance()`](#testcaseresetinstanceuse_my_controller--false) method instead.
 
 **Note:** Before you create a new controller instance, `get_instance()` returns `CIPHPUnitTestNullCodeIgniter` object.
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -115,7 +115,7 @@ load_class_instance('email', $email);
 
 ### *class* TestCase
 
-#### `TestCase::resetInstance()`
+#### `TestCase::resetInstance($use_my_controller = false)`
 
 Resets CodeIgniter instance and assign new CodeIgniter instance as `$this->CI`.
 
@@ -127,6 +127,8 @@ public function setUp()
 	$this->obj = $this->CI->Category_model;
 }
 ~~~
+
+If you want your `MY_Controller` as `$this->CI`, use `$this->resetInstance(true)`.
 
 **Note:** When you call [$this->request()](#testcaserequestmethod-argv-params--), you don't have to use this method. Because `$this->request()` resets CodeIgniter instance internally.
 


### PR DESCRIPTION
See #268

### Before

`CIPHPUnitTest::resetInstance()` creates `CI_Controller` as `$this->CI`.

### After

`CIPHPUnitTest::resetInstance()` creates `CI_Controller`. (the same as before)
`CIPHPUnitTest::resetInstance(true)` creates `MY_Controller`, if you have it.

