### PR TITLE
Allow using ci-phpunit-test directly from vendor path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ $ composer require kenjis/ci-phpunit-test --dev
 And run `install.php`:
 
 ~~~
-$ php vendor/kenjis/ci-phpunit-test/install.php
+$ php vendor/kenjis/ci-phpunit-test/install.php --from-composer
 ~~~
 
-* The above command always overwrites exisiting files.
+* The above command always overwrites existing files.
 * You must run it at CodeIgniter project root folder.
 * You can specify your `application` and `public` folder with option arguments, if you use custom folder paths.
 
@@ -94,8 +94,24 @@ If you like Composer:
 ~~~
 $ cd /path/to/codeigniter/
 $ composer update kenjis/ci-phpunit-test
-$ php vendor/kenjis/ci-phpunit-test/update.php [-a <application_dir> -p <public_dir>]
 ~~~
+
+If you're upgrading from a previous version of `ci-phpunit-test` that created
+an `application/test/_ci_phpunit_test` directory and now want to directly use
+`ci-phpunit-test` from Composer, you have a couple of additional steps:
+
+1. Delete the old test library directory: `rm -rf /path/to/codeigniter/application/tests/_ci_phpunit_test`
+2. Edit the `application/tests/Bootstrap.php` file.  At the bottom of the "set the main path constants"
+   section, add the following:
+    ```
+    define('CI_PHPUNIT_TESTPATH', implode(
+        DIRECTORY_SEPARATOR,
+        [dirname(APPPATH), 'vendor', 'kenjis', 'ci-phpunit-test', 'application', 'tests', '_ci_phpunit_test']
+    ).DIRECTORY_SEPARATOR);
+    ```
+    And replace any references to `__DIR__ . '/_ci_phpunit_test/` or `TESTPATH . '_ci_phpunit_test` with
+    `CI_PHPUNIT_TESTPATH . '`.  (So, for example, `__DIR__ . '/_ci_phpunit_test/CIPHPUnitTest.php'`
+    would become `CI_PHPUNIT_TESTPATH . '/CIPHPUnitTest.php'`.)
 
 Read [Change Log](https://github.com/kenjis/ci-phpunit-test/blob/master/application/tests/_ci_phpunit_test/ChangeLog.md).
 

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -313,6 +313,20 @@ switch (ENVIRONMENT)
 
 	define('VIEWPATH', $view_folder.DIRECTORY_SEPARATOR);
 
+	// Path to the ci-phpunit-test directory
+	if (is_dir(TESTPATH . '_ci_phpunit_test'))
+	{
+		define('CI_PHPUNIT_TESTPATH', TESTPATH . '_ci_phpunit_test' . DIRECTORY_SEPARATOR);
+	}
+	else
+	{
+		// Assume Composer with a vendor directory parallel to the application directory
+		define('CI_PHPUNIT_TESTPATH', implode(
+			DIRECTORY_SEPARATOR,
+			[dirname(APPPATH), 'vendor', 'kenjis', 'ci-phpunit-test', 'application', 'tests', '_ci_phpunit_test']
+		).DIRECTORY_SEPARATOR);
+	}
+
 /*
  * -------------------------------------------------------------------
  *  Enabling Monkey Patching
@@ -322,22 +336,22 @@ switch (ENVIRONMENT)
  * for your application.
  */
 /*
-require __DIR__ . '/_ci_phpunit_test/patcher/bootstrap.php';
+require CI_PHPUNIT_TESTPATH . 'patcher/bootstrap.php';
 MonkeyPatchManager::init([
 	// PHP Parser: PREFER_PHP7, PREFER_PHP5, ONLY_PHP7, ONLY_PHP5
 	'php_parser' => 'PREFER_PHP5',
-	'cache_dir' => TESTPATH . '_ci_phpunit_test/tmp/cache',
+	'cache_dir' => CI_PHPUNIT_TESTPATH . 'tmp/cache',
 	// Directories to patch source files
 	'include_paths' => [
 		APPPATH,
 		BASEPATH,
-		TESTPATH . '_ci_phpunit_test/replacing/',
+		CI_PHPUNIT_TESTPATH . 'replacing/',
 	],
 	// Excluding directories to patch
 	// If you want to patch files inside paths below, you must add the directory starting with '-'
 	'exclude_paths' => [
 		TESTPATH,
-		'-' . TESTPATH . '_ci_phpunit_test/replacing/',
+		'-' . CI_PHPUNIT_TESTPATH . 'replacing/',
 	],
 	// All patchers you use.
 	'patcher_list' => [
@@ -365,7 +379,7 @@ MonkeyPatchManager::init([
 define('TESTPATH', APPPATH.'tests'.DIRECTORY_SEPARATOR);
 */
 
-require __DIR__ . '/_ci_phpunit_test/CIPHPUnitTest.php';
+require CI_PHPUNIT_TESTPATH . '/CIPHPUnitTest.php';
 
 CIPHPUnitTest::init();
 // Or you can set directories for autoloading

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -314,7 +314,7 @@ switch (ENVIRONMENT)
 	define('VIEWPATH', $view_folder.DIRECTORY_SEPARATOR);
 
 	// Path to the ci-phpunit-test directory
-	if (is_dir(TESTPATH . '_ci_phpunit_test'))
+	if (is_file(TESTPATH . '_ci_phpunit_test' . DIRECTORY_SEPARATOR . 'CIPHPUnitTest.php'))
 	{
 		define('CI_PHPUNIT_TESTPATH', TESTPATH . '_ci_phpunit_test' . DIRECTORY_SEPARATOR);
 	}

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -23,6 +23,9 @@ class CIPHPUnitTest
 		if (! defined('TESTPATH')) {
 			define('TESTPATH', APPPATH.'tests'.DIRECTORY_SEPARATOR);
 		}
+		if (!defined(CI_PHPUNIT_TESTPATH)) {
+			define('CI_PHPUNIT_TESTPATH', dirname(__FILE__).DIRECTORY_SEPARATOR);
+		}
 
 		// Fix CLI args
 		$_server_backup = $_SERVER;
@@ -170,7 +173,7 @@ class CIPHPUnitTest
 	{
 		if ($dir === null)
 		{
-			$dir = TESTPATH . '_ci_phpunit_test/tmp/cache';
+			$dir = CI_PHPUNIT_TESTPATH . 'tmp/cache';
 		}
 
 		MonkeyPatchManager::setCacheDir(

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -17,6 +17,12 @@ class CIPHPUnitTest
 	 * Initialize CIPHPUnitTest
 	 *
 	 * @param array $autoload_dirs directories to search class file for autoloader
+	 *
+	 * Exclude from code coverage:  This is test suite bootstrap code, so we
+	 * know it's executed, but because it's bootstrap code, it runs outside of
+	 * any coverage tracking.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public static function init(array $autoload_dirs = null)
 	{

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -23,7 +23,8 @@ class CIPHPUnitTest
 		if (! defined('TESTPATH')) {
 			define('TESTPATH', APPPATH.'tests'.DIRECTORY_SEPARATOR);
 		}
-		if (!defined(CI_PHPUNIT_TESTPATH)) {
+        // Current Bootstrap.php should define this, but in case it doesn't:
+		if (! defined('CI_PHPUNIT_TESTPATH')) {
 			define('CI_PHPUNIT_TESTPATH', dirname(__FILE__).DIRECTORY_SEPARATOR);
 		}
 

--- a/application/tests/_ci_phpunit_test/patcher/bootstrap.php
+++ b/application/tests/_ci_phpunit_test/patcher/bootstrap.php
@@ -50,7 +50,7 @@ class_alias('Kenjis\MonkeyPatch\MonkeyPatchManager', 'MonkeyPatchManager');
 //	// Project root directory
 //	'root_dir' => APPPATH . '../',
 //	// Cache directory
-//	'cache_dir' => TESTPATH . '_ci_phpunit_test/tmp/cache',
+//	'cache_dir' => CI_PHPUNIT_TESTPATH . 'tmp/cache',
 //	// Directories to patch on source files
 //	'include_paths' => [
 //		APPPATH,

--- a/application/tests/_ci_phpunit_test/replacing/core/Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/Loader.php
@@ -1083,8 +1083,8 @@ class CI_Loader {
 
 		$class = ucfirst($class);
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$subdir.$class.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$subdir.$class.'.php'))
 		{
 			return $this->_ci_load_stock_library($class, $subdir, $params, $object_name);
 		}
@@ -1211,9 +1211,9 @@ class CI_Loader {
 		}
 
 		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php'))
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php'))
 		{
-			include_once(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php');
+			include_once(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php');
 		}
 		else
 		{

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.2-Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.2-Loader.php
@@ -1090,8 +1090,8 @@ class CI_Loader {
 
 		$class = ucfirst($class);
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$subdir.$class.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$subdir.$class.'.php'))
 		{
 			return $this->_ci_load_stock_library($class, $subdir, $params, $object_name);
 		}
@@ -1217,10 +1217,10 @@ class CI_Loader {
 			}
 		}
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php'))
 		{
-			include_once(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php');
+			include_once(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php');
 		}
 		else
 		{

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.3-Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.3-Loader.php
@@ -1079,8 +1079,8 @@ class CI_Loader {
 
 		$class = ucfirst($class);
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$subdir.$class.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$subdir.$class.'.php'))
 		{
 			return $this->_ci_load_stock_library($class, $subdir, $params, $object_name);
 		}
@@ -1206,10 +1206,10 @@ class CI_Loader {
 			}
 		}
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php'))
 		{
-			include_once(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php');
+			include_once(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php');
 		}
 		else
 		{

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.4-Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.4-Loader.php
@@ -1079,8 +1079,8 @@ class CI_Loader {
 
 		$class = ucfirst($class);
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$subdir.$class.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$subdir.$class.'.php'))
 		{
 			return $this->_ci_load_stock_library($class, $subdir, $params, $object_name);
 		}
@@ -1206,10 +1206,10 @@ class CI_Loader {
 			}
 		}
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php'))
 		{
-			include_once(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php');
+			include_once(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php');
 		}
 		else
 		{

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.5-Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.5-Loader.php
@@ -1080,7 +1080,7 @@ class CI_Loader {
 		$class = ucfirst($class);
 
 		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$subdir.$class.'.php'))
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$subdir.$class.'.php'))
 		{
 			return $this->_ci_load_stock_library($class, $subdir, $params, $object_name);
 		}
@@ -1207,9 +1207,9 @@ class CI_Loader {
 		}
 
 		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php'))
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php'))
 		{
-			include_once(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php');
+			include_once(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php');
 		}
 		else
 		{

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.6-Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.6-Loader.php
@@ -1077,8 +1077,8 @@ class CI_Loader {
 
 		$class = ucfirst($class);
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$subdir.$class.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$subdir.$class.'.php'))
 		{
 			return $this->_ci_load_stock_library($class, $subdir, $params, $object_name);
 		}
@@ -1204,10 +1204,10 @@ class CI_Loader {
 			}
 		}
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php'))
 		{
-			include_once(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php');
+			include_once(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php');
 		}
 		else
 		{

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.7-Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.7-Loader.php
@@ -1083,8 +1083,8 @@ class CI_Loader {
 
 		$class = ucfirst($class);
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$subdir.$class.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$subdir.$class.'.php'))
 		{
 			return $this->_ci_load_stock_library($class, $subdir, $params, $object_name);
 		}
@@ -1211,9 +1211,9 @@ class CI_Loader {
 		}
 
 		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php'))
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php'))
 		{
-			include_once(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php');
+			include_once(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php');
 		}
 		else
 		{

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.8-Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.8-Loader.php
@@ -1083,8 +1083,8 @@ class CI_Loader {
 
 		$class = ucfirst($class);
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$subdir.$class.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$subdir.$class.'.php'))
 		{
 			return $this->_ci_load_stock_library($class, $subdir, $params, $object_name);
 		}
@@ -1210,10 +1210,10 @@ class CI_Loader {
 			}
 		}
 
-		// Replace library in ci-phpuni-test
-		if (file_exists(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php'))
+		// Replace library in ci-phpunit-test
+		if (file_exists(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php'))
 		{
-			include_once(TESTPATH.'_ci_phpunit_test/replacing/libraries/'.$file_path.$library_name.'.php');
+			include_once(CI_PHPUNIT_TESTPATH.'replacing/libraries/'.$file_path.$library_name.'.php');
 		}
 		else
 		{

--- a/lib/Installer.php
+++ b/lib/Installer.php
@@ -14,6 +14,7 @@ class Installer
     private $app_dir = 'application';
     private $pub_dir = 'public';
     private $test_dir = 'tests';
+    private $from_composer = false;
 
     public function __construct($argv)
     {
@@ -59,6 +60,11 @@ class Installer
                     $i++;
                     break;
 
+                case '--from-composer':
+                    $this->from_composer = true;
+                    $i++;
+                    break;
+
                 default:
                     throw new Exception('Unknown argument: '.$argv[$i]);
             }
@@ -72,6 +78,9 @@ class Installer
             $this->app_dir.'/'.$this->test_dir
         );
         $this->fixPath();
+        if ($this->from_composer) {
+            $this->recursiveUnlink($this->app_dir.'/'.$this->test_dir.'/_ci_phpunit_test');
+        }
     }
 
     /**


### PR DESCRIPTION
This avoids having to clutter an application's directory with a copy of ci-phpunit-test.

To implement this, I added a `CI_PHPUNIT_TESTPATH` PHP constant that gives the location of ci-phpunit-test. It defaults to using `application/tests/_ci_phpunit_test` if that's present (so the default behavior is the same as previous versions. However, if that directory isn't present, then it looks for a `vendor` folder next to the `application` folder.

Is this general approach okay? If so, I can update this PR to update documentation and (if appropriate) to update the Composer version of the installer script.

See [these](https://github.com/kenjis/ci-phpunit-test/issues/171#issuecomment-341635380) [comments](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/master/application/tests/_ci_phpunit_test) under kenjis/ci-phpunit-test#171.

Thanks!