### PR TITLE
fixed Too many connections error.

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -85,6 +85,11 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 		chdir(FCPATH);
 	}
 
+	public static function tearDownAfterClass()
+	{
+		CIPHPUnitTestDbConnectionStore::destory();
+	}
+
 	/**
 	 * Reset CodeIgniter instance and assign new CodeIgniter instance as $this->CI
 	 */

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbConnectionStore.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbConnectionStore.php
@@ -9,11 +9,6 @@ class CIPHPUnitTestDbConnectionStore
 		self::$connections[] = $db;
 	}
 
-	public static function empty()
-	{
-		return empty(self::$connections);
-	}
-
 	public static function destory()
 	{
 		foreach (self::$connections as $db) {
@@ -25,11 +20,8 @@ class CIPHPUnitTestDbConnectionStore
 
 	private static function closeConnection(CI_DB $db)
 	{
-		if ($db->dsn === 'sqlite::memory:' || $db->database === ':memory:') {
-			return;
+		if ($db->dsn !== 'sqlite::memory:' && $db->database !== ':memory:') {
+			$db->close();
 		}
-
-		$db->close();
-		$db = null;
 	}
 }

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbConnectionStore.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbConnectionStore.php
@@ -12,7 +12,7 @@ class CIPHPUnitTestDbConnectionStore
 	public static function destory()
 	{
 		foreach (self::$connections as $db) {
-			$this->closeConnection($db);
+			self::closeConnection($db);
 		}
 
 		self::$connections = [];

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbConnectionStore.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbConnectionStore.php
@@ -1,0 +1,35 @@
+<?php
+
+class CIPHPUnitTestDbConnectionStore
+{
+	private static $connections = [];
+
+	public static function add(CI_DB $db)
+	{
+		self::$connections[] = $db;
+	}
+
+	public static function empty()
+	{
+		return empty(self::$connections);
+	}
+
+	public static function destory()
+	{
+		foreach (self::$connections as $db) {
+			$this->closeConnection($db);
+		}
+
+		self::$connections = [];
+	}
+
+	private static function closeConnection(CI_DB $db)
+	{
+		if ($db->dsn === 'sqlite::memory:' || $db->database === ':memory:') {
+			return;
+		}
+
+		$db->close();
+		$db = null;
+	}
+}

--- a/application/tests/_ci_phpunit_test/replacing/core/Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/Loader.php
@@ -400,7 +400,9 @@ class CI_Loader {
 
 		if ($return === TRUE)
 		{
-			return DB($params, $query_builder);
+			$result = DB($params, $query_builder);
+			CIPHPUnitTestDbConnectionStore::add($result);
+			return $result;
 		}
 
 		// Initialize the db variable. Needed to prevent
@@ -409,6 +411,7 @@ class CI_Loader {
 
 		// Load the DB class
 		$CI->db =& DB($params, $query_builder);
+		CIPHPUnitTestDbConnectionStore::add($CI->db);
 		return $this;
 	}
 

--- a/application/tests/_ci_phpunit_test/replacing/core/Loader.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/Loader.php
@@ -411,7 +411,6 @@ class CI_Loader {
 
 		// Load the DB class
 		$CI->db =& DB($params, $query_builder);
-		CIPHPUnitTestDbConnectionStore::add($CI->db);
 		return $this;
 	}
 


### PR DESCRIPTION
I encountered error following.

```shell
A PHP Error was encountered

Severity:    Warning
Message:     mysqli::real_connect(): (08004/1040): Too many connections
Filename:    /vagrant/html/vendor/codeigniter/framework/system/database/drivers/mysqli/mysqli_driver.php
Line Number: 201
```

ci-phpunit-test is no close database connection, when call Loader::database second argument true.
for that reason encount error when frequent call Loader::database method in test case.

This problem solution is following.

* create collection class for db connection.
* collect db connection when call Loader::database second argument is true.
* close db connection from collected when call `CIPHPUnitTestCase::tearDownAfterClass`.