### PR TITLE
Added return type methods where required by PHPUnit 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ As an example, a test case class for `Inventory_model` would be as follows:
 
 class Inventory_model_test extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->resetInstance();
         $this->CI->load->model('Inventory_model');

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -72,7 +72,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 		throw new LogicException('No such property: ' . $name);
 	}
 
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
 		// Fix CLI args, because you may set invalid URI characters
 		// For example, when you run tests on NetBeans
@@ -85,7 +85,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 		chdir(FCPATH);
 	}
 
-	public static function tearDownAfterClass()
+	public static function tearDownAfterClass(): void
 	{
 		CIPHPUnitTestDbConnectionStore::destory();
 	}
@@ -100,7 +100,7 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 		$this->CI =& get_instance();
 	}
 
-	protected function tearDown()
+	protected function tearDown(): void
 	{
 		$this->disableStrictErrorCheck();
 

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
@@ -41,7 +41,7 @@ class CIPHPUnitTestDbTestCase extends CIPHPUnitTestCase
 		}
 	}
 
-	protected function setUp()
+	protected function setUp(): void
 	{
 		$this->loadDependencies();
 	}
@@ -52,7 +52,7 @@ class CIPHPUnitTestDbTestCase extends CIPHPUnitTestCase
 	 * Takes care of any required cleanup after the test, like
 	 * removing any rows inserted via $this->hasInDatabase()
 	 */
-	protected function tearDown()
+	protected function tearDown(): void
 	{
 		if (! empty($this->insertCache))
 		{

--- a/application/tests/_ci_phpunit_test/patcher/third_party/PHP-Parser-2.1.1/test/PhpParser/Builder/InterfaceTest.php
+++ b/application/tests/_ci_phpunit_test/patcher/third_party/PHP-Parser-2.1.1/test/PhpParser/Builder/InterfaceTest.php
@@ -12,7 +12,7 @@ class InterfaceTest extends \PHPUnit_Framework_TestCase
     /** @var Interface_ */
     protected $builder;
 
-    protected function setUp() {
+    protected function setUp(): void {
         $this->builder = new Interface_('Contract');
     }
 

--- a/application/tests/_ci_phpunit_test/patcher/third_party/PHP-Parser-3.0.3/test/PhpParser/Builder/InterfaceTest.php
+++ b/application/tests/_ci_phpunit_test/patcher/third_party/PHP-Parser-3.0.3/test/PhpParser/Builder/InterfaceTest.php
@@ -12,7 +12,7 @@ class InterfaceTest extends \PHPUnit_Framework_TestCase
     /** @var Interface_ */
     protected $builder;
 
-    protected function setUp() {
+    protected function setUp(): void {
         $this->builder = new Interface_('Contract');
     }
 

--- a/docs/FunctionAndClassReference.md
+++ b/docs/FunctionAndClassReference.md
@@ -120,7 +120,7 @@ load_class_instance('email', $email);
 Resets CodeIgniter instance and assign new CodeIgniter instance as `$this->CI`.
 
 ~~~php
-public function setUp()
+public function setUp(): void
 {
 	$this->resetInstance();
 	$this->CI->load->model('Category_model');
@@ -135,7 +135,7 @@ public function setUp()
 Before v0.6.0, we write `setUp()` method like this:
 
 ~~~php
-public function setUp()
+public function setUp(): void
 {
 	$this->CI =& get_instance();
 	$this->CI->load->model('Category_model');
@@ -657,7 +657,7 @@ To use this test case, you must install `application/tests/UnitTestCase.php` man
 Resets CodeIgniter instance and return new model instance. This method is for model unit testing.
 
 ~~~php
-public function setUp()
+public function setUp(): void
 {
 	$this->obj = $this->newModel('Category_model');
 }
@@ -675,7 +675,7 @@ public function setUp()
 Resets CodeIgniter instance and return new library instance. This method is for library unit testing.
 
 ~~~php
-public function setUp()
+public function setUp(): void
 {
 	$this->obj = $this->newLibrary('Foo_library');
 }

--- a/docs/HowToWriteTests.md
+++ b/docs/HowToWriteTests.md
@@ -221,7 +221,7 @@ You must put all directories to search class files in the array.
 ~~~php
 class Foo_test extends TestCase
 {
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->resetInstance();
 		$this->CI->load->library('Foo');
@@ -249,7 +249,7 @@ class Foo_test extends TestCase
 
 class Inventory_model_test extends TestCase
 {
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->resetInstance();
 		$this->CI->load->model('shop/Inventory_model');
@@ -289,9 +289,9 @@ They are not installed, so if you want to use, copy them manually.
 You can use them like below:
 
 ~~~php
-	public static function setUpBeforeClass()
+	public static function setUpBeforeClass(): void
 	{
-		parent::setUpBeforeClass();
+		parent::setUpBeforeClass(): void;
 
 		$CI =& get_instance();
 		$CI->load->library('Seeder');
@@ -334,7 +334,7 @@ You can use `$this->getMockBuilder()` method in PHPUnit and [$this->verifyInvoke
 If you don't know well about PHPUnit Mock Objects, see [Test Doubles](https://phpunit.de/manual/current/en/test-doubles.html).
 
 ~~~php
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->obj = $this->newModel('Category_model');
 	}
@@ -395,7 +395,7 @@ See [working sample](https://github.com/kenjis/ci-app-for-ci-phpunit-test/blob/v
 If your library depends on CodeIgniter functionality, I recommend using `setUp()` method like this:
 
 ~~~php
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->resetInstance();
 		$this->CI->load->library('Someclass');
@@ -406,7 +406,7 @@ If your library depends on CodeIgniter functionality, I recommend using `setUp()
 If your library is decoupled from CodeIgniter functionality, you can use `setUp()` method like this:
 
 ~~~php
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->obj = new Someclass();
 	}
@@ -796,7 +796,7 @@ With mock libraries, you could replace your object in CodeIgniter instance.
 This is how to replace Email library with `Mock_Libraries_Email` class.
 
 ~~~php
-	public function setUp()
+	public function setUp(): void
 	{
 		$this->resetInstance();
 		$this->CI->load->model('Mail_model');


### PR DESCRIPTION
Simply adds the return type methods as required by PHPUnit 8 [https://phpunit.de/announcements/phpunit-8.html](https://phpunit.de/announcements/phpunit-8.html).

This allows the libary to be used by those wanting to use the latest version of PHPUnit.

I expect some if not all of the CI builds will fail as I don't believe any are using PHPUnit 8. This change would also stop old versions working so perhaps it needs to go into a new branch? 