### PR TITLE
CI instance reference error in CIPHPUnitTestDbTestCase.

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
@@ -83,7 +83,7 @@ class CIPHPUnitTestDbTestCase extends CIPHPUnitTestCase
 
 		$CI =& get_instance();
 		$CI->load->database();
-		$this->db = $this->CI->db;
+		$this->db = $CI->db;
 	}
 
 	//--------------------------------------------------------------------


### PR DESCRIPTION
fix typo.

I encountered following error.

```
A PHP Error was encountered

Severity:    Notice
Message:     Trying to get property of non-object
Filename:    /vagrant/vendor/kenjis/ci-phpunit-test/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
Line Number: 86
```