### PR TITLE
Fixed a bug that reconnects DB every time when conn_id type is resource.

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
@@ -74,7 +74,7 @@ class CIPHPUnitTestDbTestCase extends CIPHPUnitTestCase
 	 */
 	private function checkDbConnId()
 	{
-		if (is_object($this->db->conn_id)) {
+		if (is_object($this->db->conn_id) || is_resource($this->db->conn_id)) {
 			return;
 		}
 


### PR DESCRIPTION
DB_driver supported by CodeIgniter may include  conn_id to resource.
And CIPHPUnitTestDbTestCase will reconnect if con_id is not an object.
Namely CIPHPUnitTestDbTestCase is every time reconnect  when conn_id is resource.