### PR TITLE
Fixed a bug that reconnects DB every time when conn_id type is resource for v2.x.

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
@@ -74,7 +74,7 @@ class CIPHPUnitTestDbTestCase extends CIPHPUnitTestCase
 	 */
 	private function checkDbConnId()
 	{
-		if (is_object($this->db->conn_id)) {
+		if (is_object($this->db->conn_id) || is_resource($this->db->conn_id)) {
 			return;
 		}
 


### PR DESCRIPTION
see: https://github.com/kenjis/ci-phpunit-test/pull/301