### PR TITLE
Support namespace style PHPUnit MockObject

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDouble.php
@@ -57,7 +57,7 @@ class CIPHPUnitTestDouble
 
 		foreach ($params as $method => $return)
 		{
-			if (is_object($return) && $return instanceof PHPUnit_Framework_MockObject_Stub) {
+			if (is_object($return) && ($return instanceof PHPUnit_Framework_MockObject_Stub || $return instanceof PHPUnit\Framework\MockObject\Stub)) {
 				$mock->expects($this->testCase->any())->method($method)
 					->will($return);
 			} elseif (is_object($return) && $return instanceof Closure) {


### PR DESCRIPTION
I encountered the following error.

```bash
TypeError: Return value of Mock_Hoge_fetcher_7b0f1a88::fetch() must be an instance of Hoge_response_object, instance of PHPUnit\Framework\MockObject\Stub\Exception returned
```

This error occurs because `phpunit-mock-objects` is renewed.

Relation links 👇.

- https://github.com/kenjis/ci-phpunit-test/pull/170#issuecomment-279366023
- https://github.com/sebastianbergmann/phpunit-mock-objects/blob/master/src/Stub.php