### PR TITLE
Load modified helpers before loading CI core files

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -74,6 +74,9 @@ class CIPHPUnitTest
 		// Change current directory
 		chdir(FCPATH);
 
+    // Replace helpers before loading CI (which could auto load helpers)
+		self::replaceHelpers();
+    
 		/*
 		 * --------------------------------------------------------------------
 		 * LOAD THE BOOTSTRAP FILE
@@ -82,8 +85,6 @@ class CIPHPUnitTest
 		 * And away we go...
 		 */
 		require __DIR__ . '/replacing/core/CodeIgniter.php';
-
-		self::replaceHelpers();
 
 		// Create CodeIgniter instance
 		if (! self::wiredesignzHmvcInstalled())


### PR DESCRIPTION
Fix **#309 - redirect() - url_helper autoload - Cannot modify header information**