### PR TITLE
fix: Class 'PHPUnit_Util_Configuration' not found

### DIFF
--- a/application/tests/_ci_phpunit_test/ChangeLog.md
+++ b/application/tests/_ci_phpunit_test/ChangeLog.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 * Fix bug that config files are not loaded with HMVC. See [#327](https://github.com/kenjis/ci-phpunit-test/pull/327), [#328](https://github.com/kenjis/ci-phpunit-test/pull/328).
+* Fix bug that NetBeans test suite provider causes `Class 'PHPUnit_Util_Configuration' not found`. See [#313](https://github.com/kenjis/ci-phpunit-test/pull/313).
 
 ## v0.17.3 (2020/02/05)
 

--- a/application/tests/_ci_phpunit_test/TestSuiteProvider.php
+++ b/application/tests/_ci_phpunit_test/TestSuiteProvider.php
@@ -2,7 +2,7 @@
 /**
  * Test Suite Provider for NetBeans
  * https://github.com/BrickieToolShed/netbeans-phpunit-support
- * 
+ *
  * Modified 2015 by Kenji Suzuki <https://github.com/kenjis>
  * @link       https://github.com/kenjis/ci-phpunit-test
  */
@@ -41,6 +41,11 @@ namespace netbeans\phpunit\support;
 
 use PHPUnit_Framework_TestSuite;
 use PHPUnit_Util_Configuration;
+
+// Support PHPUnit 6.0
+if (! class_exists('PHPUnit_Util_Configuration')) {
+    class_alias('PHPUnit\Util\Configuration', 'PHPUnit_Util_Configuration');
+}
 
 /**
  * TestSuiteProvider


### PR DESCRIPTION
See https://github.com/kenjis/ci-phpunit-test/issues/265