### PR TITLE
fix: when you enable exit patcher only, it causes errors

### DIFF
--- a/application/tests/_ci_phpunit_test/ChangeLog.md
+++ b/application/tests/_ci_phpunit_test/ChangeLog.md
@@ -1,5 +1,11 @@
 # Change Log for ci-phpunit-test
 
+## v0.17.2 (Not Released)
+
+### Fixed
+
+* Fix bug when you enable exit patcher only, it causes errors. See [#320](https://github.com/kenjis/ci-phpunit-test/pull/320).
+
 ## v0.17.1 (2020/01/22)
 
 ### Fixed

--- a/application/tests/_ci_phpunit_test/patcher/2.x/MonkeyPatchManager.php
+++ b/application/tests/_ci_phpunit_test/patcher/2.x/MonkeyPatchManager.php
@@ -141,14 +141,18 @@ class MonkeyPatchManager
 
 		self::loadPatchers();
 
-		self::addTmpFunctionBlacklist();
-
-		if (isset($config['functions_to_patch']))
+		if (static::isEnabled('FunctionPatcher'))
 		{
-			FunctionPatcher::addWhitelists($config['functions_to_patch']);
+			self::addTmpFunctionBlacklist();
+
+			if (isset($config['functions_to_patch']))
+			{
+				FunctionPatcher::addWhitelists($config['functions_to_patch']);
+			}
+
+			self::checkFunctionWhitelistUpdate();
+			FunctionPatcher::lockFunctionList();
 		}
-		self::checkFunctionWhitelistUpdate();
-		FunctionPatcher::lockFunctionList();
 
 		if (isset($config['exit_exception_classname']))
 		{

--- a/application/tests/_ci_phpunit_test/patcher/3.x/MonkeyPatchManager.php
+++ b/application/tests/_ci_phpunit_test/patcher/3.x/MonkeyPatchManager.php
@@ -141,14 +141,18 @@ class MonkeyPatchManager
 
 		self::loadPatchers();
 
-		self::addTmpFunctionBlacklist();
-
-		if (isset($config['functions_to_patch']))
+		if (static::isEnabled('FunctionPatcher'))
 		{
-			FunctionPatcher::addWhitelists($config['functions_to_patch']);
+			self::addTmpFunctionBlacklist();
+
+			if (isset($config['functions_to_patch']))
+			{
+				FunctionPatcher::addWhitelists($config['functions_to_patch']);
+			}
+
+			self::checkFunctionWhitelistUpdate();
+			FunctionPatcher::lockFunctionList();
 		}
-		self::checkFunctionWhitelistUpdate();
-		FunctionPatcher::lockFunctionList();
 
 		if (isset($config['exit_exception_classname']))
 		{

--- a/application/tests/_ci_phpunit_test/patcher/4.x/MonkeyPatchManager.php
+++ b/application/tests/_ci_phpunit_test/patcher/4.x/MonkeyPatchManager.php
@@ -141,14 +141,18 @@ class MonkeyPatchManager
 
 		self::loadPatchers();
 
-		self::addTmpFunctionBlacklist();
-
-		if (isset($config['functions_to_patch']))
+		if (static::isEnabled('FunctionPatcher'))
 		{
-			FunctionPatcher::addWhitelists($config['functions_to_patch']);
+			self::addTmpFunctionBlacklist();
+
+			if (isset($config['functions_to_patch']))
+			{
+				FunctionPatcher::addWhitelists($config['functions_to_patch']);
+			}
+
+			self::checkFunctionWhitelistUpdate();
+			FunctionPatcher::lockFunctionList();
 		}
-		self::checkFunctionWhitelistUpdate();
-		FunctionPatcher::lockFunctionList();
 
 		if (isset($config['exit_exception_classname']))
 		{


### PR DESCRIPTION
Fix the error:
```
Fatal error: Class 'Kenjis\MonkeyPatch\Patcher\FunctionPatcher' not found
```
