### PR TITLE
Fix buggy tearDown() with MySQL

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbTestCase.php
@@ -54,6 +54,8 @@ class CIPHPUnitTestDbTestCase extends CIPHPUnitTestCase
 	 */
 	protected function tearDown()
 	{
+		$this->checkDbConnId();
+		
 		if (! empty($this->insertCache))
 		{
 			foreach ($this->insertCache as $row)


### PR DESCRIPTION
Fixes a problem where calling `tearDown` also results in a PHP Error:
```
Uncaught Error: Call to a member function real_escape_string() on bool in [...]/vendor/codeigniter/framework/system/database/drivers/mysqli/mysqli_driver.php:393
```