### PR TITLE
fix too many connection.

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestDbConnectionStore.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestDbConnectionStore.php
@@ -18,10 +18,27 @@ class CIPHPUnitTestDbConnectionStore
 		self::$connections = [];
 	}
 
-	private static function closeConnection(CI_DB $db)
+	public static function closeConnection(CI_DB $db)
 	{
-		if ($db->dsn !== 'sqlite::memory:' && $db->database !== ':memory:') {
-			$db->close();
+		if ($db->dsn === 'sqlite::memory:' && $db->database === ':memory:') {
+			return;
+		}
+
+		self::cleanUpReference($db);
+		$db->close();
+	}
+
+	private static function cleanUpReference(CI_DB $db)
+	{
+		if ($db->dbdriver === 'oci8') {
+			if (is_resource($db->curs_id)) {
+				oci_free_statement($db->curs_id);
+			}
+			if (is_resource($db->stmt_id)) {
+				oci_free_statement($db->stmt_id);
+			}
+		} elseif ($db->dbdriver === 'pdo') {
+			$db->result_id = null;
 		}
 	}
 }

--- a/application/tests/_ci_phpunit_test/functions.php
+++ b/application/tests/_ci_phpunit_test/functions.php
@@ -33,14 +33,14 @@ function reset_instance()
 
 	// Close db connection
 	$CI =& get_instance();
-	if (isset($CI->db))
+	if (isset($CI->db) && $CI->db instanceof CI_DB)
 	{
 		if (
 			$CI->db->dsn !== 'sqlite::memory:'
 			&& $CI->db->database !== ':memory:'
 		)
 		{
-			$CI->db->close();
+			CIPHPUnitTestDbConnectionStore::closeConnection($CI->db);
 			$CI->db = null;
 		}
 		else


### PR DESCRIPTION
I ran the following error when I ran about 3000 unit tests.

ORA-01000

The cause is that the cursor became huge because oci_free_statement was not performed.

This code reduced the oracle open cursor by a factor of ten.

I hope the following fixes will be fixed in CodeIgniter.

https://github.com/bcit-ci/CodeIgniter/pull/5896
https://github.com/bcit-ci/CodeIgniter/pull/5895

but as described in the comments below, it is a problem that does not easily occur when using CodeIgniter alone, so I created a PR here as well.

> Just in principle, if something is completely outside of CI's control it's also not CI's responsibility to handle it, but even if we ignore that, this "fix" is very likely just masking an undiagnosed problem somewhere else.
