### PR TITLE
Fix php-parser version for monkey patching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "nikic/php-parser": "^2.1|^3.0|^4.2"
+        "nikic/php-parser": "^2.1|^3.0|4.6.*"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
php-parser v4.9 is not compatible with monkey patching.
