### PR TITLE
Fix loading constatns.php

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -20,7 +20,7 @@ class CIPHPUnitTest
 	 *
 	 * @param array $autoload_dirs directories to search class file for autoloader
 	 *
-	 * Exclude from code coverage:  This is test suite bootstrap code, so we
+	 * Exclude from code coverage: This is test suite bootstrap code, so we
 	 * know it's executed, but because it's bootstrap code, it runs outside of
 	 * any coverage tracking.
 	 *

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -28,13 +28,7 @@ class CIPHPUnitTest
 	 */
 	public static function init(array $autoload_dirs = null)
 	{
-		if (! defined('TESTPATH')) {
-			define('TESTPATH', APPPATH.'tests'.DIRECTORY_SEPARATOR);
-		}
-		// Current Bootstrap.php should define this, but in case it doesn't:
-		if (! defined('CI_PHPUNIT_TESTPATH')) {
-			define('CI_PHPUNIT_TESTPATH', dirname(__FILE__).DIRECTORY_SEPARATOR);
-		}
+		self::defineConstants();
 
 		// Fix CLI args
 		$_server_backup = $_SERVER;
@@ -51,19 +45,7 @@ class CIPHPUnitTest
 		// Load autoloader for ci-phpunit-test
 		require __DIR__ . '/autoloader.php';
 
-		require TESTPATH . 'TestCase.php';
-
-		$db_test_case_file = TESTPATH . 'DbTestCase.php';
-		if (is_readable($db_test_case_file))
-		{
-			require $db_test_case_file;
-		}
-
-		$unit_test_case_file = TESTPATH . 'UnitTestCase.php';
-		if (is_readable($unit_test_case_file))
-		{
-			require $unit_test_case_file;
-		}
+		self::loadTestCaseClasses();
 
 		// Replace a few Common functions
 		require __DIR__ . '/replacing/core/Common.php';
@@ -118,6 +100,34 @@ class CIPHPUnitTest
 
 		// Restore cwd to use `Usage: phpunit [options] <directory>`
 		chdir($cwd_backup);
+	}
+
+	public static function defineConstants()
+	{
+		if (! defined('TESTPATH')) {
+			define('TESTPATH', APPPATH.'tests'.DIRECTORY_SEPARATOR);
+		}
+		// Current Bootstrap.php should define this, but in case it doesn't:
+		if (! defined('CI_PHPUNIT_TESTPATH')) {
+			define('CI_PHPUNIT_TESTPATH', dirname(__FILE__).DIRECTORY_SEPARATOR);
+		}
+	}
+
+	public static function loadTestCaseClasses()
+	{
+		require TESTPATH . 'TestCase.php';
+
+		$db_test_case_file = TESTPATH . 'DbTestCase.php';
+		if (is_readable($db_test_case_file))
+		{
+			require $db_test_case_file;
+		}
+
+		$unit_test_case_file = TESTPATH . 'UnitTestCase.php';
+		if (is_readable($unit_test_case_file))
+		{
+			require $unit_test_case_file;
+		}
 	}
 
 	/**

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -92,7 +92,7 @@ class CIPHPUnitTest
 		chdir($cwd_backup);
 	}
 
-	public static function loadCodeIgniter(){
+	private static function loadCodeIgniter(){
 		// Load constants.php before replacing helpers,
 		// because config_item() loads config.php
 		if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/constants.php'))
@@ -118,7 +118,7 @@ class CIPHPUnitTest
 		require __DIR__ . '/replacing/core/CodeIgniter.php';
 	}
 
-	public static function defineConstants()
+	private static function defineConstants()
 	{
 		if (! defined('TESTPATH')) {
 			define('TESTPATH', APPPATH.'tests'.DIRECTORY_SEPARATOR);
@@ -129,7 +129,7 @@ class CIPHPUnitTest
 		}
 	}
 
-	public static function loadTestCaseClasses()
+	private static function loadTestCaseClasses()
 	{
 		require TESTPATH . 'TestCase.php';
 

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -93,6 +93,18 @@ class CIPHPUnitTest
 	}
 
 	public static function loadCodeIgniter(){
+		// Load constants.php before replacing helpers,
+		// because config_item() loads config.php
+		if (file_exists(APPPATH.'config/'.ENVIRONMENT.'/constants.php'))
+		{
+			require_once(APPPATH.'config/'.ENVIRONMENT.'/constants.php');
+		}
+
+		if (file_exists(APPPATH.'config/constants.php'))
+		{
+			require_once(APPPATH.'config/constants.php');
+		}
+
 		// Replace helpers before loading CI (which could auto load helpers)
 		self::replaceHelpers();
 

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTest.php
@@ -67,17 +67,7 @@ class CIPHPUnitTest
 		// Change current directory
 		chdir(FCPATH);
 
-		// Replace helpers before loading CI (which could auto load helpers)
-		self::replaceHelpers();
-
-		/*
-		 * --------------------------------------------------------------------
-		 * LOAD THE BOOTSTRAP FILE
-		 * --------------------------------------------------------------------
-		 *
-		 * And away we go...
-		 */
-		require __DIR__ . '/replacing/core/CodeIgniter.php';
+		self::loadCodeIgniter();
 
 		// Create CodeIgniter instance
 		if (! self::wiredesignzHmvcInstalled())
@@ -100,6 +90,20 @@ class CIPHPUnitTest
 
 		// Restore cwd to use `Usage: phpunit [options] <directory>`
 		chdir($cwd_backup);
+	}
+
+	public static function loadCodeIgniter(){
+		// Replace helpers before loading CI (which could auto load helpers)
+		self::replaceHelpers();
+
+		/*
+		 * --------------------------------------------------------------------
+		 * LOAD THE BOOTSTRAP FILE
+		 * --------------------------------------------------------------------
+		 *
+		 * And away we go...
+		 */
+		require __DIR__ . '/replacing/core/CodeIgniter.php';
 	}
 
 	public static function defineConstants()

--- a/application/tests/_ci_phpunit_test/ChangeLog.md
+++ b/application/tests/_ci_phpunit_test/ChangeLog.md
@@ -6,6 +6,10 @@
 
 * Add functionality to create mocks on consecutive calls. See [#339](https://github.com/kenjis/ci-phpunit-test/pull/339).
 
+### Fixed
+
+* Fix bug that `config.php` is loaded before `constants.php`. See [#348](https://github.com/kenjis/ci-phpunit-test/pull/348).
+
 ## v0.18.0 (2020/05/17)
 
 ### Added


### PR DESCRIPTION
Now `config.php` is loaded before `constants.php`.
This behavior is the reverse to how CI does.

See <https://github.com/kenjis/ci-phpunit-test/issues/151#issuecomment-675019769>.
