### PR TITLE
Add is_testing_env() to check whether the environment is testing or not

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
     - php: 7.3
     - php: 7.4
 
+env:
+  global:
+    - XDEBUG_MODE=coverage
+
 before_script:
   - pwd
   - export cwd=`pwd`

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -63,12 +63,7 @@ if (! defined('ENVIRONMENT'))
 // If you want to change `testing`, you must define `is_testing_env()`.
 //function is_testing_env()
 //{
-//	if (ENVIRONMENT === 'unittest')
-//	{
-//		return TRUE;
-//	}
-//
-//	return FALSE;
+//    return (ENVIRONMENT === 'unittest');
 //}
 
 /*

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -56,7 +56,7 @@
 
 // Define testing environment for ci-phpunit-test
 // This `if` statement is needed for @runInSeparateProcess
-if (! defined('ENVIRONMENT'))
+if ( ! defined('ENVIRONMENT'))
 {
 	define('ENVIRONMENT', 'testing');
 }

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -53,11 +53,23 @@
  *
  * NOTE: If you change these, also change the error_reporting() code below
  */
-// This `if` statemant is needed for @runInSeparateProcess
+
+// Define testing environment for ci-phpunit-test
+// This `if` statement is needed for @runInSeparateProcess
 if (! defined('ENVIRONMENT'))
 {
 	define('ENVIRONMENT', 'testing');
 }
+// If you want to change `testing`, you must define `is_testing_env()`.
+//function is_testing_env()
+//{
+//	if (ENVIRONMENT === 'unittest')
+//	{
+//		return TRUE;
+//	}
+//
+//	return FALSE;
+//}
 
 /*
  *---------------------------------------------------------------

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -55,9 +55,9 @@
  */
 
 // Define testing environment for ci-phpunit-test
-// This `if` statement is needed for @runInSeparateProcess
 if ( ! defined('ENVIRONMENT'))
 {
+	// The above `if` statement is needed for @runInSeparateProcess
 	define('ENVIRONMENT', 'testing');
 }
 // If you want to change `testing`, you must define `is_testing_env()`.

--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -61,9 +61,13 @@ if ( ! defined('ENVIRONMENT'))
 	define('ENVIRONMENT', 'testing');
 }
 // If you want to change `testing`, you must define `is_testing_env()`.
-//function is_testing_env()
+//if ( ! function_exists('is_testing_env'))
 //{
-//    return (ENVIRONMENT === 'unittest');
+//	// The above `if` statement is needed for @runInSeparateProcess
+//	function is_testing_env()
+//	{
+//		return (ENVIRONMENT === 'unittest');
+//	}
 //}
 
 /*

--- a/application/tests/_ci_phpunit_test/ChangeLog.md
+++ b/application/tests/_ci_phpunit_test/ChangeLog.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Add functionality to create mocks on consecutive calls. See [#339](https://github.com/kenjis/ci-phpunit-test/pull/339).
+* Add functionality to change `ENVIRONMENT` constant value `testing`. See [#354](https://github.com/kenjis/ci-phpunit-test/pull/354).
 
 ### Fixed
 

--- a/application/tests/_ci_phpunit_test/functions.php
+++ b/application/tests/_ci_phpunit_test/functions.php
@@ -114,3 +114,21 @@ function reset_config()
 	get_config([], TRUE);
 	config_item(NULL, TRUE);
 }
+
+if ( ! function_exists('is_testing_env'))
+{
+	/**
+	 * Testing Environment or not?
+	 *
+	 * @return bool
+	 */
+	function is_testing_env()
+	{
+		if (ENVIRONMENT === 'testing')
+		{
+			return TRUE;
+		}
+
+		return FALSE;
+	}
+}

--- a/application/tests/_ci_phpunit_test/functions.php
+++ b/application/tests/_ci_phpunit_test/functions.php
@@ -124,11 +124,6 @@ if ( ! function_exists('is_testing_env'))
 	 */
 	function is_testing_env()
 	{
-		if (ENVIRONMENT === 'testing')
-		{
-			return TRUE;
-		}
-
-		return FALSE;
+		return (ENVIRONMENT === 'testing');
 	}
 }

--- a/application/tests/_ci_phpunit_test/replacing/core/Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/Common.php
@@ -301,7 +301,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.0.0-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.0.0-Common.php
@@ -273,7 +273,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.0-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.0-Common.php
@@ -273,7 +273,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.2-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.2-Common.php
@@ -279,7 +279,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.3-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.3-Common.php
@@ -279,7 +279,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.4-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.4-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.5-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.5-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.6-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.6-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.7-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.7-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.8-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.8-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.9-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.9-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (ENVIRONMENT === 'testing')
+	if (is_testing_env())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (ENVIRONMENT === 'testing')
+		if (is_testing_env())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if (ENVIRONMENT !== 'testing')
+			if ( ! is_testing_env())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-download_helper.php
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (ENVIRONMENT === 'testing')
+		if (is_testing_env())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if (ENVIRONMENT !== 'testing')
+			if ( ! is_testing_env())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-download_helper.php
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (ENVIRONMENT === 'testing')
+		if (is_testing_env())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if (ENVIRONMENT !== 'testing')
+			if ( ! is_testing_env())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-download_helper.php
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (ENVIRONMENT === 'testing')
+		if (is_testing_env())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if (ENVIRONMENT !== 'testing')
+			if ( ! is_testing_env())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-download_helper.php
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (ENVIRONMENT === 'testing')
+		if (is_testing_env())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if (ENVIRONMENT !== 'testing')
+			if ( ! is_testing_env())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if (ENVIRONMENT !== 'testing')
+				if ( ! is_testing_env())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if (ENVIRONMENT !== 'testing')
+		if ( ! is_testing_env())
 		{
 			exit;
 		}


### PR DESCRIPTION
- Add `is_testing_env()` function to check whether the current environment is testing or not.
- When you do not want to set `ENVIRONMENT` constant `testing` , you could define `is_testing_env()` in your `Bootstrap.php`.

Example:
```php
if ( ! function_exists('is_testing_env'))
{
	// The above `if` statement is needed for @runInSeparateProcess
	function is_testing_env()
	{
		return (ENVIRONMENT === 'unittest');
	}
}
```
