### PR TITLE
Replace `is_testing_env()` with `TestCase::isTestingEnv()`

### DIFF
--- a/application/tests/Bootstrap.php
+++ b/application/tests/Bootstrap.php
@@ -60,15 +60,6 @@ if ( ! defined('ENVIRONMENT'))
 	// The above `if` statement is needed for @runInSeparateProcess
 	define('ENVIRONMENT', 'testing');
 }
-// If you want to change `testing`, you must define `is_testing_env()`.
-//if ( ! function_exists('is_testing_env'))
-//{
-//	// The above `if` statement is needed for @runInSeparateProcess
-//	function is_testing_env()
-//	{
-//		return (ENVIRONMENT === 'unittest');
-//	}
-//}
 
 /*
  *---------------------------------------------------------------

--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestCase.php
@@ -454,4 +454,14 @@ class CIPHPUnitTestCase extends PHPUnit_Framework_TestCase
 		$result = CIPHPUnitTestLogger::didLog($level, $message);
 		$this->assertTrue($result);
 	}
+
+	/**
+	 * Testing Environment or not?
+	 *
+	 * @return bool
+	 */
+	public static function isTestingEnv()
+	{
+		return (ENVIRONMENT === 'testing');
+	}
 }

--- a/application/tests/_ci_phpunit_test/ChangeLog.md
+++ b/application/tests/_ci_phpunit_test/ChangeLog.md
@@ -5,7 +5,7 @@
 ### Added
 
 * Add functionality to create mocks on consecutive calls. See [#339](https://github.com/kenjis/ci-phpunit-test/pull/339).
-* Add functionality to change `ENVIRONMENT` constant value `testing`. See [#354](https://github.com/kenjis/ci-phpunit-test/pull/354).
+* Add functionality to change `ENVIRONMENT` constant value `testing`. See [#360](https://github.com/kenjis/ci-phpunit-test/pull/360).
 
 ### Fixed
 

--- a/application/tests/_ci_phpunit_test/functions.php
+++ b/application/tests/_ci_phpunit_test/functions.php
@@ -114,16 +114,3 @@ function reset_config()
 	get_config([], TRUE);
 	config_item(NULL, TRUE);
 }
-
-if ( ! function_exists('is_testing_env'))
-{
-	/**
-	 * Testing Environment or not?
-	 *
-	 * @return bool
-	 */
-	function is_testing_env()
-	{
-		return (ENVIRONMENT === 'testing');
-	}
-}

--- a/application/tests/_ci_phpunit_test/replacing/core/Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/Common.php
@@ -301,7 +301,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.0.0-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.0.0-Common.php
@@ -273,7 +273,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.0-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.0-Common.php
@@ -273,7 +273,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.2-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.2-Common.php
@@ -279,7 +279,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.3-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.3-Common.php
@@ -279,7 +279,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.4-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.4-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.5-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.5-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.6-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.6-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.7-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.7-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.8-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.8-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/core/old/3.1.9-Common.php
+++ b/application/tests/_ci_phpunit_test/replacing/core/old/3.1.9-Common.php
@@ -275,7 +275,7 @@ function set_status_header($code = 200, $text = '')
 
 	// Everything is done, so return
 	// added by ci-phpunit-test
-	if (is_testing_env())
+	if (TestCase::isTestingEnv())
 	{
 		return;
 	}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (is_testing_env())
+		if (TestCase::isTestingEnv())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if ( ! is_testing_env())
+			if ( ! TestCase::isTestingEnv())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (is_testing_env())
+		if (TestCase::isTestingEnv())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if ( ! is_testing_env())
+			if ( ! TestCase::isTestingEnv())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.6-url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (is_testing_env())
+		if (TestCase::isTestingEnv())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if ( ! is_testing_env())
+			if ( ! TestCase::isTestingEnv())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.7-url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (is_testing_env())
+		if (TestCase::isTestingEnv())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if ( ! is_testing_env())
+			if ( ! TestCase::isTestingEnv())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.8-url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-download_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-download_helper.php
@@ -98,7 +98,7 @@ if ( ! function_exists('force_download'))
 			return;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			// Clean output buffer
 			if (ob_get_level() !== 0 && @ob_end_clean() === FALSE)
@@ -115,7 +115,7 @@ if ( ! function_exists('force_download'))
 			header('Cache-Control: private, no-transform, no-store, must-revalidate');
 		}
 
-		if (is_testing_env())
+		if (TestCase::isTestingEnv())
 		{
 			$CI =& get_instance();
 			$CI->output->set_header('Content-Type: '.$mime);
@@ -134,7 +134,7 @@ if ( ! function_exists('force_download'))
 		// If we have raw data - just dump it
 		if ($data !== NULL)
 		{
-			if ( ! is_testing_env())
+			if ( ! TestCase::isTestingEnv())
 			{
 				exit($data);
 			}
@@ -152,7 +152,7 @@ if ( ! function_exists('force_download'))
 		}
 
 		fclose($fp);
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/old/3.1.9-url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}

--- a/application/tests/_ci_phpunit_test/replacing/helpers/url_helper.php
+++ b/application/tests/_ci_phpunit_test/replacing/helpers/url_helper.php
@@ -52,20 +52,20 @@ if ( ! function_exists('redirect'))
 		switch ($method)
 		{
 			case 'refresh':
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Refresh:0;url='.$uri);
 				}
 				break;
 			default:
-				if ( ! is_testing_env())
+				if ( ! TestCase::isTestingEnv())
 				{
 					header('Location: '.$uri, TRUE, $code);
 				}
 				break;
 		}
 
-		if ( ! is_testing_env())
+		if ( ! TestCase::isTestingEnv())
 		{
 			exit;
 		}


### PR DESCRIPTION
Refactors #354

- remove `is_testing_env()`
- add `CIPHPUnitTestCase::isTestingEnv()`

When you do not want to set `ENVIRONMENT` constant `testing`, you could define `isTestingEnv()` in your `TestCase.php`.

Example:
```php
	public static function isTestingEnv()
	{
		return (ENVIRONMENT === 'unittest');
	}
```
