### PR TITLE
Fixing URI error on installation

### DIFF
--- a/lib/Installer.php
+++ b/lib/Installer.php
@@ -96,7 +96,7 @@ class Installer
         );
         $this->fixPath();
         if ($this->from_composer) {
-            $this->recursiveUnlink($this->app_dir.'/'.$this->test_dir.'/_ci_phpunit_test');
+            $this->recursiveUnlink($this->test_dir.'/_ci_phpunit_test');
         }
     }
 


### PR DESCRIPTION
When executing:

`$ php vendor/kenjis/ci-phpunit-test/install.php --from-composer`

The following error message is shown:

```
PHP Fatal error:  Uncaught UnexpectedValueException: RecursiveDirectoryIterator::__construct(application/application/tests/_ci_phpunit_test): failed to open dir: No such file or directory in /home/vagrant/test/vendor/kenjis/ci-phpunit-test/lib/Installer.php:214
Stack trace:
#0 /home/vagrant/test/vendor/kenjis/ci-phpunit-test/lib/Installer.php(214): RecursiveDirectoryIterator->__construct()
#1 /home/vagrant/test/vendor/kenjis/ci-phpunit-test/lib/Installer.php(99): Installer->recursiveUnlink()
#2 /home/vagrant/test/vendor/kenjis/ci-phpunit-test/install.php(14): Installer->install()
#3 {main}
  thrown in /home/vagrant/test/vendor/kenjis/ci-phpunit-test/lib/Installer.php on line 214

```

This was tested either in Debian 9 and Windows with different CI versions.

This pull request aims to solve this situation.
