### PR TITLE
Exclude views/errors/ for PHPUnit coverage report

### DIFF
--- a/application/tests/phpunit.xml
+++ b/application/tests/phpunit.xml
@@ -19,6 +19,9 @@
 			<directory suffix=".php">../helpers</directory>
 			<directory suffix=".php">../hooks</directory>
 		</include>
+		<exclude>
+			<directory suffix=".php">../views/errors</directory>
+		</exclude>
 		<report>
 			<html outputDirectory="build/coverage" lowUpperBound="50" highLowerBound="90"/>
 			<clover outputFile="build/logs/clover.xml"/>


### PR DESCRIPTION
Without this, the following error occurs when generating coverage report.

```
Generating code coverage report in Clover XML format ... 
ERROR: 
A PHP Error was encountered

Severity:    Notice
Message:     Undefined variable: heading
Filename:    .../application/views/errors/cli/error_404.php
Line Number: 5
```
