### PR TITLE
Fixed flock warn

### DIFF
--- a/application/tests/_ci_phpunit_test/patcher/IncludeStream.php
+++ b/application/tests/_ci_phpunit_test/patcher/IncludeStream.php
@@ -208,7 +208,7 @@ class IncludeStream
 
 	public function stream_lock($operation)
 	{
-		return flock($this->resource, $operation);
+		return flock($this->resource, $operation || LOCK_EX);
 	}
 
 	public function stream_set_option($option, $arg1, $arg2)

--- a/application/tests/_ci_phpunit_test/patcher/IncludeStream.php
+++ b/application/tests/_ci_phpunit_test/patcher/IncludeStream.php
@@ -208,7 +208,10 @@ class IncludeStream
 
 	public function stream_lock($operation)
 	{
-		return flock($this->resource, $operation || LOCK_EX);
+		if ($operation === '0' || $operation === 0) {
+			$operation = LOCK_EX;
+		}
+		return flock($this->resource, $operation);
 	}
 
 	public function stream_set_option($option, $arg1, $arg2)


### PR DESCRIPTION
It appears as if `flock()` requires the second param `$operation`. See https://github.com/antecedent/patchwork/issues/27#issuecomment-146955543. 

This is impacting current project of mine, where issue #377  is coming. This PR fixes it