### PR TITLE
fix: pre_controller can't modify $class / $method

### DIFF
--- a/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
+++ b/application/tests/_ci_phpunit_test/CIPHPUnitTestRequest.php
@@ -324,7 +324,12 @@ class CIPHPUnitTestRequest
 	{
 		ob_start();
 
+		$GLOBALS['class'] = $class;
+		$GLOBALS['method'] = $method;
+		// pre_controller can modify global $class $method variables to modify route
 		$this->callHook('pre_controller');
+		$class = $GLOBALS['class'];
+		$method = $GLOBALS['method'];
 
 		// Run callablePreConstructor
 		if ($this->callablePreConstructors !== [])


### PR DESCRIPTION
in codeigniter pre_controller methods modifying global `$class` `$method` variables can modify the route

code in codeigniter\framework\system\core\CodeIgniter.php 
```php
$EXT->call_hook('pre_controller');
$BM->mark('controller_execution_time_( '.$class.' / '.$method.' )_start');
$CI = new $class();
```
with this fix, this behavior will work in testing also